### PR TITLE
add a note about installing node.js first for debian/rpm installs

### DIFF
--- a/docs/installation/debian.adoc
+++ b/docs/installation/debian.adoc
@@ -6,6 +6,10 @@ These instructions assume that https://grafana.com[Grafana] is NOT already insta
 If you have an existing instance of https://grafana.com[Grafana] you would like to use, refer to xref:../installation/plugin.adoc#[Installing via plugin].
 ====
 
+== Install Node.js
+
+First, follow the instructions at https://nodejs.org/en/download/package-manager/#debian-and-ubuntu-based-linux-distributions[the Node.js site] for installing Node.js (6.x or higher).
+
 == Install stable
 
 Create a new apt source file (eg: `/etc/apt/sources.list.d/opennms.list`), and add the following 2 lines:

--- a/docs/installation/rpm.adoc
+++ b/docs/installation/rpm.adoc
@@ -6,6 +6,10 @@ These instructions assume that https://grafana.com[Grafana] is NOT already insta
 If you have an existing instance of https://grafana.com[Grafana] you would like to use, refer to xref:../installation/plugin.adoc#[Installing via plugin].
 ====
 
+== Install Node.js
+
+First, follow the instructions at https://nodejs.org/en/download/package-manager/#enterprise-linux-and-fedora[the Node.js site] for installing Node.js (6.x or higher).
+
 == Install stable
 
 Install the package repository:


### PR DESCRIPTION
Normally for CentOS 7 installation, you would just enable the `epel` repo and get Node.js there, but since RHEL7.4 is about to come out, EPEL has removed some of Node's dependencies and installation is broken.

This patch adds a note about installing Node.js through the official upstream's recommendation for package installs so that we don't have to worry about broken dependencies.