### PR TITLE
HELM-68: Bump grafana base image 4.4.1 -> 4.6.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM grafana/grafana:4.4.1
+FROM grafana/grafana:4.6.0
 
 ARG NODEJS_SETUP_SCRIPT_URL=https://deb.nodesource.com/setup_6.x
 ARG YARN_KEY_URL=https://dl.yarnpkg.com/debian/pubkey.gpg


### PR DESCRIPTION
Upgrade to use latest Grafana stable version 4.6.0 instead of 4.4.1.