### PR TITLE
HELM-71: display errors for incomplete queries

### DIFF
--- a/src/datasources/perf-ds/datasource.js
+++ b/src/datasources/perf-ds/datasource.js
@@ -47,9 +47,8 @@ export class OpenNMSDatasource {
         headers: {'Content-Type': 'application/json'}
       });
     } else {
-      // There are no sources listed, use an empty set of measurements
-      request = this.$q.defer();
-      request.resolve({measurements: []});
+      // There are no sources listed, let Grafana display "No data points" to the user
+      return;
     }
 
     // Convert the results to the expected format

--- a/src/datasources/perf-ds/partials/query.editor.html
+++ b/src/datasources/perf-ds/partials/query.editor.html
@@ -9,7 +9,7 @@
             </label>
             <select class="gf-form-input"
                     ng-model="ctrl.target.type"
-                    ng-blur="ctrl.targetBlur()">
+                    ng-blur="ctrl.targetBlur('type')">
                 <option data-ng-repeat="(key, value) in ctrl.types" value="{{ value }}">{{ key }}</option>
             </select>
         </div>
@@ -30,7 +30,7 @@
 
                        placeholder="node id"
                        data-min-length=0 data-items=100
-                       ng-blur="ctrl.targetBlur()"
+                       ng-blur="ctrl.targetBlur('nodeId')"
                 >
             </div>
         </div>
@@ -48,7 +48,7 @@
 
                        placeholder="resource id"
                        data-min-length=0 data-items=100
-                       ng-blur="ctrl.targetBlur()"
+                       ng-blur="ctrl.targetBlur('resourceId')"
                 >
             </div>
         </div>
@@ -67,7 +67,7 @@
 
                            placeholder="attribute"
                            data-min-length=0 data-items=100
-                           ng-blur="ctrl.targetBlur()"
+                           ng-blur="ctrl.targetBlur('attribute')"
                     >
                 </div>
             </div>
@@ -83,7 +83,7 @@
 
                            placeholder="subattribute"
                            data-min-length=0 data-items=100
-                           ng-blur="ctrl.targetBlur()"
+                           ng-blur="ctrl.targetBlur('subattribute')"
                     >
                 </div>
             </div>
@@ -94,7 +94,7 @@
                     </label>
                     <select class="gf-form-input"
                             ng-model="ctrl.target.aggregation"
-                            ng-blur="ctrl.targetBlur()">
+                            ng-blur="ctrl.targetBlur('aggregation')">
                         <option value="AVERAGE">Average</option>
                         <option value="MIN">Min</option>
                         <option value="MAX">Max</option>
@@ -116,7 +116,7 @@
                    spellcheck='false'
                    placeholder="series expression"
                    data-min-length=0 data-items=2048
-                   ng-blur="ctrl.targetBlur()"
+                   ng-blur="ctrl.targetBlur('expression')"
             />
         </div>
     </div>
@@ -136,7 +136,7 @@
 
                        placeholder="filter type name"
                        data-min-length=0 data-items=100
-                       ng-blur="ctrl.targetBlur()"
+                       ng-blur="ctrl.targetBlur('filterName')"
                 />
             </div>
         </div>
@@ -152,7 +152,7 @@
                        spellcheck='false'
                        placeholder="{{ param.default != null ? param.default : '' }}"
                        data-min-length=0 data-items=100
-                       ng-blur="targetBlur()"
+                       ng-blur="targetBlur('filterParameter')"
                 >
                 <div class="help-block">
                     {{ param.description }}
@@ -172,7 +172,7 @@
                    spellcheck='false'
                    placeholder="series label"
                    data-min-length=0 data-items=100
-                   ng-blur="ctrl.targetBlur()"
+                   ng-blur="ctrl.targetBlur('label')"
             />
         </div>
     </div>

--- a/src/datasources/perf-ds/query_ctrl.js
+++ b/src/datasources/perf-ds/query_ctrl.js
@@ -1,6 +1,7 @@
 import './modal_ctrl';
 import {QueryType} from './constants';
 import {QueryCtrl} from 'app/plugins/sdk';
+import appEvents from 'app/core/app_events';
 import _ from 'lodash';
 
 export class OpenNMSQueryCtrl extends QueryCtrl {
@@ -170,8 +171,12 @@ export class OpenNMSQueryCtrl extends QueryCtrl {
   }
 
   targetBlur() {
-    this.error = this.validateTarget();
-    this.refresh();
+    if (this.error = this.validateTarget()) {
+      appEvents.emit('alert-error', ['Error', this.error]);
+    } else {
+      // Only send valid requests to the API
+      this.refresh();
+    }
   }
 
   validateTarget() {

--- a/src/spec/test-main.js
+++ b/src/spec/test-main.js
@@ -10,6 +10,9 @@ prunk.mock('app/plugins/sdk', {
   QueryCtrl: null,
   loadPluginCss: () => {}
 });
+prunk.mock('app/core/app_events', {
+  appEvents: null
+});
 
 // Setup jsdom
 // Required for loading angularjs


### PR DESCRIPTION
Display error messages from validateTarget() instead of silently
submitting API requests that are expected to fail.

This PoC causes a lot of noise during normal editing of queries,
so a more intelligent validation should probably be performed
during intermediary edits.