### PR TITLE
HELM-75: required Grafana version is missing

### DIFF
--- a/docs/installation/debian.adoc
+++ b/docs/installation/debian.adoc
@@ -4,6 +4,8 @@
 ====
 These instructions assume that https://grafana.com[Grafana] is NOT already installed on the target system.
 If you have an existing instance of https://grafana.com[Grafana] you would like to use, refer to xref:../installation/plugin.adoc#[Installing via plugin].
+
+The required Grafana-Server version is *4.4.1* up to *< 5*.
 ====
 
 == Install stable

--- a/docs/installation/plugin.adoc
+++ b/docs/installation/plugin.adoc
@@ -4,6 +4,8 @@
 ====
 These instructions assume that https://grafana.com[Grafana] is already installed on the target system.
 If you do have an existing instance of https://grafana.com[Grafana], refer to xref:../installation/install-centos-redhat.adoc#[Installing on RPM-based Linux (CentOS, Fedora, OpenSuse, RedHat)] or xref:../installation/install-debian-ubuntu.adoc#[Installing on Debian / Ubuntu].
+
+The required Grafana-Server version is *4.4.1* up to *< 5*.
 ====
 
 == Install the application

--- a/docs/installation/rpm.adoc
+++ b/docs/installation/rpm.adoc
@@ -4,6 +4,8 @@
 ====
 These instructions assume that https://grafana.com[Grafana] is NOT already installed on the target system.
 If you have an existing instance of https://grafana.com[Grafana] you would like to use, refer to xref:../installation/plugin.adoc#[Installing via plugin].
+
+The required Grafana-Server version is *4.4.1* up to *< 5*.
 ====
 
 == Install stable

--- a/docs/installation/source.adoc
+++ b/docs/installation/source.adoc
@@ -3,6 +3,7 @@
 == Requirements
 
 * http://docs.grafana.org/installation[Grafana]
+The required Grafana-Server version is *4.4.1* up to *< 5*.
 * https://yarnpkg.com/en/docs/install[yarn]
 * https://nodejs.org/en/download[Node.js >= 6.x]
 


### PR DESCRIPTION
As discussed I added it into the installation section. But I don't like to have it 4 times in the docs.
What do you think? Other suggestions?


https://issues.opennms.org/browse/HELM-75
