### PR TITLE
HELM-86: add support for configurable timeouts

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "babel-plugin-transform-es2015-modules-systemjs": "^6.24.1",
     "babel-preset-es2015": "^6.24.1",
     "lodash": "~4.17.4",
-    "opennms": "^1.1.1",
+    "opennms": "^1.2.0",
     "q": "^1.5.0"
   },
   "homepage": "https://github.com/OpenNMS/opennms-helm",

--- a/src/components/timeout.html
+++ b/src/components/timeout.html
@@ -1,0 +1,13 @@
+<div class="section gf-form-group">
+    <h3 class="page-heading">
+        Miscellaneous HTTP Settings
+    </h3>
+    <div class="gf-form-group">
+        <div class="gf-form-inline">
+            <div class="gf-form">
+                <label class="gf-form-label width-12">ReST Timeout (Seconds)</label>
+                <input type="text" class="gf-form-input width-4" ng-model="ctrl.current.jsonData.timeout" ng-pattern="ctrl.patterns.number" placeholder="10">
+            </div>
+        </div>
+    </div>
+</div>

--- a/src/components/timeout.js
+++ b/src/components/timeout.js
@@ -1,0 +1,34 @@
+const directive = () => {
+  return {
+    templateUrl: 'public/plugins/opennms-helm-app/components/timeout.html',
+    restrict: 'E',
+    controller: 'OnmsTimeoutCtrl',
+    controllerAs: 'ctrl',
+    bindToController: true,
+    scope: {
+      current: '='
+    }
+  };
+};
+
+class OnmsTimeoutCtrl {
+  constructor() {
+      if (!this.current) {
+      console.log('no current controller!');
+      }
+    if (!this.current.jsonData.timeout) {
+      this.current.jsonData.timeout = 10;
+    }
+    this.patterns = {
+      timeout: /^\d+$/
+    };
+  }
+}
+
+if (typeof angular !== 'undefined') {
+  angular.module('grafana.directives')
+    .directive('onmsTimeoutSettings', directive)
+    .controller('OnmsTimeoutCtrl', OnmsTimeoutCtrl);
+} else {
+  console.warn('Angular not found!  <onms-timeout> will not work!');
+}

--- a/src/datasources/fault-ds/module.js
+++ b/src/datasources/fault-ds/module.js
@@ -1,6 +1,7 @@
 import {OpenNMSFMDatasource} from './datasource';
 import {OpenNMSFMDatasourceQueryCtrl} from './query_ctrl';
 import {Examples} from './Examples';
+import '../../components/timeout';
 
 class OpenNMSFMDatasourceConfigCtrl {}
 OpenNMSFMDatasourceConfigCtrl.templateUrl = 'datasources/fault-ds/partials/config.html';

--- a/src/datasources/fault-ds/partials/config.html
+++ b/src/datasources/fault-ds/partials/config.html
@@ -1,5 +1,7 @@
 <datasource-http-settings current="ctrl.current">
 </datasource-http-settings>
+<onms-timeout-settings current="ctrl.current">
+</onms-timeout-settings>
 
 <h3 class="page-heading">OpenNMS FM Datasource Details</h3>
 <div class="gf-form-group">

--- a/src/datasources/flow-ds/module.js
+++ b/src/datasources/flow-ds/module.js
@@ -1,5 +1,6 @@
 import {FlowDatasource} from './datasource';
 import {FlowDatasourceQueryCtrl} from './query_ctrl';
+import '../../components/timeout';
 
 class GenericConfigCtrl {}
 

--- a/src/datasources/flow-ds/partials/config.html
+++ b/src/datasources/flow-ds/partials/config.html
@@ -1,2 +1,4 @@
 <datasource-http-settings current="ctrl.current">
 </datasource-http-settings>
+<onms-timeout-settings current="ctrl.current">
+</onms-timeout-settings>

--- a/src/datasources/perf-ds/datasource.js
+++ b/src/datasources/perf-ds/datasource.js
@@ -11,6 +11,10 @@ export class OpenNMSDatasource {
     this.basicAuth = instanceSettings.basicAuth;
     this.withCredentials = instanceSettings.withCredentials;
 
+    if (instanceSettings.jsonData && instanceSettings.jsonData.timeout) {
+        this.timeout = parseInt(instanceSettings.jsonData.timeout,10) * 1000;
+    }
+
     this.$q = $q;
     this.backendSrv = backendSrv;
     this.templateSrv = templateSrv;
@@ -29,6 +33,9 @@ export class OpenNMSDatasource {
     }
 
     options.url = this.url + options.url;
+    if (this.timeout) {
+      options.timeout = this.timeout;
+    }
 
     return this.backendSrv.datasourceRequest(options);
   };

--- a/src/datasources/perf-ds/module.js
+++ b/src/datasources/perf-ds/module.js
@@ -1,6 +1,7 @@
 import {OpenNMSDatasource} from './datasource';
 import {OpenNMSQueryCtrl} from './query_ctrl';
 import {loadPluginCss} from 'app/plugins/sdk';
+import '../../components/timeout';
 
 class GenericConfigCtrl {}
 GenericConfigCtrl.templateUrl = 'datasources/perf-ds/partials/config.html';

--- a/src/datasources/perf-ds/partials/config.html
+++ b/src/datasources/perf-ds/partials/config.html
@@ -1,2 +1,4 @@
 <datasource-http-settings current="ctrl.current">
 </datasource-http-settings>
+<onms-timeout-settings current="ctrl.current">
+</onms-timeout-settings>

--- a/src/lib/client_delegate.js
+++ b/src/lib/client_delegate.js
@@ -37,7 +37,7 @@ export class ClientDelegate {
     getClientWithMetadata() {
         if (!this.clientWithMetadata) {
               let self = this;
-              let client = Client.getMetadata(this.client.server, this.client.http)
+              let client = Client.getMetadata(self.client.server, self.client.http, self.timeout)
                 .then(function(metadata) {
                     // Ensure the OpenNMS we are talking to is compatible
                     if (metadata.apiVersion() !== 2) {

--- a/src/lib/client_delegate.js
+++ b/src/lib/client_delegate.js
@@ -11,6 +11,10 @@ export class ClientDelegate {
         this.searchLimit = 1000;
         this.$q = $q;
 
+        if (settings.jsonData && settings.jsonData.timeout) {
+            this.timeout = parseInt(settings.jsonData.timeout,10) * 1000;
+        }
+
         let authConfig = undefined;
         if (settings.basicAuth) {
           // If basic auth is configured, pass the username and password to the client
@@ -24,7 +28,7 @@ export class ClientDelegate {
         }
 
         let server = new API.OnmsServer(this.name, this.url, authConfig);
-        let http = new Rest.GrafanaHTTP(this.backendSrv, server);
+        let http = new Rest.GrafanaHTTP(this.backendSrv, server, this.timeout);
         this.client = new Client(http);
         this.client.server = server;
         this.clientWithMetadata = undefined;

--- a/yarn.lock
+++ b/yarn.lock
@@ -2545,9 +2545,9 @@ onetime@^1.0.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/onetime/-/onetime-1.1.0.tgz#a1f7838f8314c516f05ecefcbc4ccfe04b4ed789"
 
-opennms@^1.1.1:
-  version "1.1.1"
-  resolved "https://registry.yarnpkg.com/opennms/-/opennms-1.1.1.tgz#e6bb82e0e349ce17fc961d5399758bd90adb71d8"
+opennms@^1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/opennms/-/opennms-1.2.0.tgz#9683cdc93d8404e9e2876cbb6f6851ecba456d6d"
   dependencies:
     axios "^0.16.1"
     cli-table "^0.3.1"


### PR DESCRIPTION
This PR builds on [HELM-78](https://github.com/OpenNMS/opennms-helm/pull/49) to add configurable timeout support to the Helm datasources.