### PR TITLE
HELM-87: implement fallback-attribute in grafana perf-ds

### DIFF
--- a/src/datasources/perf-ds/datasource.js
+++ b/src/datasources/perf-ds/datasource.js
@@ -189,6 +189,7 @@ export class OpenNMSDatasource {
         var source = {
           "aggregation": target.aggregation,
           "attribute": target.attribute,
+          "fallback-attribute": target.fallbackAttribute,
           "label": label,
           "resourceId": target.resourceId,
           "nodeId": target.nodeId, // temporary attribute used for interpolation

--- a/src/datasources/perf-ds/datasource.js
+++ b/src/datasources/perf-ds/datasource.js
@@ -189,7 +189,6 @@ export class OpenNMSDatasource {
         var source = {
           "aggregation": target.aggregation,
           "attribute": target.attribute,
-          "fallback-attribute": target.fallbackAttribute,
           "label": label,
           "resourceId": target.resourceId,
           "nodeId": target.nodeId, // temporary attribute used for interpolation
@@ -198,6 +197,9 @@ export class OpenNMSDatasource {
 
         if (target.subattribute !== undefined && target.subattribute !== '') {
           source.datasource = target.subattribute;
+        }
+        if (target.fallbackAttribute !== undefined && target.fallbackAttribute !== '') {
+          source['fallback-attribute'] = target.fallbackAttribute;
         }
 
         // Perform variable substitution - may generate additional queries

--- a/src/datasources/perf-ds/partials/query.editor.html
+++ b/src/datasources/perf-ds/partials/query.editor.html
@@ -56,7 +56,7 @@
             <div class="gf-form-inline">
                 <div class="gf-form max-width-25">
                     <a class="gf-form-label query-keyword width-10"
-                       ng-click="ctrl.openAttributeSelectionModal();"
+                       ng-click="ctrl.openAttributeSelectionModal('attribute');"
                        role="menuitem">
                         Attribute <i class="fa fa-tag"></i>
                     </a>
@@ -87,11 +87,14 @@
                     >
                 </div>
             </div>
+        <div ng-show="ctrl.target.resourceId">
             <div class="gf-form-inline">
                 <div class="gf-form max-width-25">
-                    <label class="gf-form-label query-keyword width-10">
+                    <a class="gf-form-label query-keyword width-10"
+                       ng-click="ctrl.openAttributeSelectionModal('fallbackAttribute');"
+                       role="menuitem">
                         Fallback Attribute <i class="fa fa-tag"></i>
-                    </label>
+                    </a>
                     <input type="text"
                            class="gf-form-input"
                            ng-model="ctrl.target.fallbackAttribute"

--- a/src/datasources/perf-ds/partials/query.editor.html
+++ b/src/datasources/perf-ds/partials/query.editor.html
@@ -90,6 +90,21 @@
             <div class="gf-form-inline">
                 <div class="gf-form max-width-25">
                     <label class="gf-form-label query-keyword width-10">
+                        Fallback Attribute <i class="fa fa-tag"></i>
+                    </label>
+                    <input type="text"
+                           class="gf-form-input"
+                           ng-model="ctrl.target.fallbackAttribute"
+                           spellcheck="false"
+                           placeholder="fallback attribute"
+                           data-min-length=0 data-items=100
+                           ng-blur="ctrl.targetBlur()"
+                    >
+                </div>
+            </div>
+            <div class="gf-form-inline">
+                <div class="gf-form max-width-25">
+                    <label class="gf-form-label query-keyword width-10">
                         Aggregation <i class="fa fa-calculator"></i>
                     </label>
                     <select class="gf-form-input"

--- a/src/datasources/perf-ds/query_ctrl.js
+++ b/src/datasources/perf-ds/query_ctrl.js
@@ -102,8 +102,13 @@ export class OpenNMSQueryCtrl extends QueryCtrl {
     });
   }
 
-  openAttributeSelectionModal() {
+  openAttributeSelectionModal(prop) {
     var self = this;
+
+    if (!prop) {
+      prop = 'attribute';
+    }
+
     this.showSelectionModal("attributes", {
       'Name': 'name'
     }, function (query) {
@@ -122,7 +127,7 @@ export class OpenNMSQueryCtrl extends QueryCtrl {
           };
         });
     }, function (attribute) {
-      self.target.attribute = attribute.name;
+      self.target[prop] = attribute.name;
       self.targetBlur();
     });
   }


### PR DESCRIPTION
Pretty straightforward, this PR implements support for `fallback-attribute` in the performance datasource.  I confirmed it by typo-ing the attribute and then providing a valid value (`ifInOctets`) for the `fallback-attribute` and I still get graphs, so it seems to be working as expected.  :)