### PR TITLE
simplify plugin summary to fit the plugin registry page

### DIFF
--- a/src/plugin.json
+++ b/src/plugin.json
@@ -3,7 +3,7 @@
   "id": "opennms-helm-app",
   "type": "app",
   "info": {
-    "description": "Helm is a Grafana plugin that allows you to create flexible dashboards using both using both fault management (FM) and performance management (PM) data from OpenNMS® Horizon™ and/or OpenNMS® Meridian™.",
+    "description": "Create flexible dashboards using data from OpenNMS® Horizon™ and/or OpenNMS® Meridian™.",
     "author": {
       "name": "The OpenNMS Group Inc.",
       "url": "https://www.opennms.com"


### PR DESCRIPTION
This PR changes the `plugin.json` description to be shorter so it fits nicely in the summary box on the Grafana plugin registry page.  Currently they cut it off with `...`:

![example](https://i.imgur.com/95euw5K.png)