### PR TITLE
HELM-97: Fix for "Template variable were only replaced once"

### DIFF
--- a/src/datasources/perf-ds/interpolate.js
+++ b/src/datasources/perf-ds/interpolate.js
@@ -60,7 +60,7 @@ function defaultReplace(value, variables) {
   }
   var interpolatedValue = value;
   _.each(variables, function (variable) {
-    interpolatedValue = interpolatedValue.replace("$" + variable.name, variable.value);
+    interpolatedValue = interpolatedValue.replace(new RegExp("\\$" + variable.name, "g"), variable.value);
   });
   return interpolatedValue;
 }

--- a/src/datasources/perf-ds/interpolate.js
+++ b/src/datasources/perf-ds/interpolate.js
@@ -60,7 +60,8 @@ function defaultReplace(value, variables) {
   }
   var interpolatedValue = value;
   _.each(variables, function (variable) {
-    interpolatedValue = interpolatedValue.replace(new RegExp("\\$" + variable.name, "g"), variable.value);
+    var regexVarName = "\\$" + variable.name.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+    interpolatedValue = interpolatedValue.replace(new RegExp(regexVarName, "g"), variable.value);
   });
   return interpolatedValue;
 }


### PR DESCRIPTION
The String.replace() function only replaces the first occurence of a found element, when used with a substring as parameter. I changed the parameter to a RegExp to replace all occurences of template variables. 