### PR TITLE
HELM-100: allow overriding time intervals and max datapoints

### DIFF
--- a/src/datasources/perf-ds/datasource.js
+++ b/src/datasources/perf-ds/datasource.js
@@ -10,6 +10,7 @@ export class OpenNMSDatasource {
     this.name = instanceSettings.name;
     this.basicAuth = instanceSettings.basicAuth;
     this.withCredentials = instanceSettings.withCredentials;
+    this.interval = (instanceSettings.jsonData || {}).timeInterval;
 
     if (instanceSettings.jsonData && instanceSettings.jsonData.timeout) {
         this.timeout = parseInt(instanceSettings.jsonData.timeout,10) * 1000;
@@ -191,6 +192,7 @@ export class OpenNMSDatasource {
       start = options.range.from.valueOf(),
       end = options.range.to.valueOf(),
       step = Math.floor((end - start) / options.maxDataPoints);
+      step = (step < options.intervalMs) ? options.intervalMs : step;
 
     var query = {
       "start": start,

--- a/src/datasources/perf-ds/partials/config.html
+++ b/src/datasources/perf-ds/partials/config.html
@@ -2,3 +2,19 @@
 </datasource-http-settings>
 <onms-timeout-settings current="ctrl.current">
 </onms-timeout-settings>
+<h3 class="page-heading">OpenNMS PM Datasource Details</h3>
+<div class="section gf-form-group">
+    <div class="gf-form-inline">
+        <div class="gf-form">
+            <span class="gf-form-label">Min time interval</span>
+            <input type="text" class="gf-form-input width-6" ng-model="ctrl.current.jsonData.timeInterval" spellcheck='false' placeholder="10s"></input>
+            <info-popover mode="right-absolute">
+                A lower limit for the auto group by time interval. Recommended to be set to write frequency,
+                for example <code>1m</code> if your data is written every minute.
+
+                When using Newts as the Time Series Strategy, org.opennms.newts.query.minimum_step may end up
+                overriding this setting.
+            </info-popover>
+        </div>
+    </div>
+</div>

--- a/src/datasources/perf-ds/plugin.json
+++ b/src/datasources/perf-ds/plugin.json
@@ -10,6 +10,11 @@
   "metrics": true,
   "annotations": false,
 
+  "queryOptions": {
+    "minInterval": true,
+    "maxDataPoints": true
+  },
+
   "info": {
     "logos": {
       "small": "img/pm-ds.svg",


### PR DESCRIPTION
This commit adds support for setting a global time interval for the PM datasource and optionally overriding it per query. Max datapoints can also be specified per query.

Allowing a global default is useful when the minimum_step setting in OpenNMS is lower than what you'd want to use for most graphs. (For example when polling certain services every 60 seconds, but everything else at a larger interval.)

One new configuration option for the PM datasource:
![intervals_global](https://user-images.githubusercontent.com/1952603/42411430-340baa26-81fc-11e8-8a97-9b726446e4f0.png)

Two new graph query options:
![intervals_query](https://user-images.githubusercontent.com/1952603/42411431-37fc3b28-81fc-11e8-8a73-da537bc3f792.png)

