### PR TITLE
HELM-101: avoid initialization errors

### DIFF
--- a/src/datasources/perf-ds/datasource.js
+++ b/src/datasources/perf-ds/datasource.js
@@ -84,8 +84,8 @@ export class OpenNMSDatasource {
         headers: {'Content-Type': 'application/json'}
       });
     } else {
-      // There are no sources listed, use an empty set of measurements
-      request = this.$q.resolve({measurements: []});
+      // There are no sources listed, let Grafana display "No data points" to the user
+      return;
     }
 
     // Convert the results to the expected format

--- a/src/datasources/perf-ds/datasource.js
+++ b/src/datasources/perf-ds/datasource.js
@@ -85,7 +85,7 @@ export class OpenNMSDatasource {
       });
     } else {
       // There are no sources listed, let Grafana display "No data points" to the user
-      return;
+      return {'data': []};
     }
 
     // Convert the results to the expected format


### PR DESCRIPTION
 - JIRA: https://issues.opennms.org/browse/HELM-101

Instead of displaying errors on all freshly initialized panels:
![originalpanels](https://user-images.githubusercontent.com/1952603/43345529-174afd36-91ee-11e8-8269-ae511a9a9baa.png)

... return an empty 'data' array, and let Grafana inform the user that there isn't any data available (yet):
![fixedpanels](https://user-images.githubusercontent.com/1952603/43345533-1b663e08-91ee-11e8-969a-e69236556056.png)

