### PR TITLE
HELM-71: display errors for incomplete queries

### DIFF
--- a/src/datasources/perf-ds/partials/query.editor.html
+++ b/src/datasources/perf-ds/partials/query.editor.html
@@ -7,9 +7,9 @@
                     <i class="fa fa-warning"></i>
                 </label>
             </label>
-            <select class="gf-form-input"
+            <select class="gf-form-input" ng-required="true"
                     ng-model="ctrl.target.type"
-                    ng-blur="ctrl.targetBlur()">
+                    ng-blur="ctrl.targetBlur('type')">
                 <option data-ng-repeat="(key, value) in ctrl.types" value="{{ value }}">{{ key }}</option>
             </select>
         </div>
@@ -23,14 +23,14 @@
                    role="menuitem">
                     Node <i class="fa fa-tree"></i>
                 </a>
-                <input type="text"
+                <input type="text" ng-required="true"
                        class="gf-form-input"
                        ng-model="ctrl.target.nodeId"
                        spellcheck='false'
 
                        placeholder="node id"
                        data-min-length=0 data-items=100
-                       ng-blur="ctrl.targetBlur()"
+                       ng-blur="ctrl.targetBlur('nodeId')"
                 >
             </div>
         </div>
@@ -41,14 +41,14 @@
                    role="menuitem">
                     Resource <i class="fa fa-leaf"></i>
                 </a>
-                <input type="text"
+                <input type="text" ng-required="true"
                        class="gf-form-input"
                        ng-model="ctrl.target.resourceId"
                        spellcheck='false'
 
                        placeholder="resource id"
                        data-min-length=0 data-items=100
-                       ng-blur="ctrl.targetBlur()"
+                       ng-blur="ctrl.targetBlur('resourceId')"
                 >
             </div>
         </div>
@@ -60,14 +60,14 @@
                        role="menuitem">
                         Attribute <i class="fa fa-tag"></i>
                     </a>
-                    <input type="text"
+                    <input type="text" ng-required="true"
                            class="gf-form-input"
                            ng-model="ctrl.target.attribute"
                            spellcheck='false'
 
                            placeholder="attribute"
                            data-min-length=0 data-items=100
-                           ng-blur="ctrl.targetBlur()"
+                           ng-blur="ctrl.targetBlur('attribute')"
                     >
                 </div>
             </div>
@@ -83,7 +83,7 @@
 
                            placeholder="subattribute"
                            data-min-length=0 data-items=100
-                           ng-blur="ctrl.targetBlur()"
+                           ng-blur="ctrl.targetBlur('subattribute', false)"
                     >
                 </div>
             </div>
@@ -100,7 +100,7 @@
                            spellcheck="false"
                            placeholder="fallback attribute"
                            data-min-length=0 data-items=100
-                           ng-blur="ctrl.targetBlur()"
+                           ng-blur="ctrl.targetBlur('fallbackAttribute', false)"
                     >
                 </div>
             </div>
@@ -111,7 +111,7 @@
                     </label>
                     <select class="gf-form-input"
                             ng-model="ctrl.target.aggregation"
-                            ng-blur="ctrl.targetBlur()">
+                            ng-blur="ctrl.targetBlur('aggregation', false)">
                         <option value="AVERAGE">Average</option>
                         <option value="MIN">Min</option>
                         <option value="MAX">Max</option>
@@ -127,13 +127,13 @@
             <label class="gf-form-label query-keyword width-10">
                 Expression <i class="fa fa-calculator"></i>
             </label>
-            <input type="text"
+            <input type="text" ng-required="true"
                    class="gf-form-input max-width-30"
                    ng-model="ctrl.target.expression"
                    spellcheck='false'
                    placeholder="series expression"
                    data-min-length=0 data-items=2048
-                   ng-blur="ctrl.targetBlur()"
+                   ng-blur="ctrl.targetBlur('expression')"
             />
         </div>
     </div>
@@ -146,14 +146,14 @@
                    role="menuitem">
                     Filter <i class="fa fa-filter"></i>
                 </a>
-                <input type="text"
+                <input type="text" ng-required="true"
                        class="gf-form-input"
                        ng-model="ctrl.target.filter.name"
                        spellcheck='false'
 
                        placeholder="filter type name"
                        data-min-length=0 data-items=100
-                       ng-blur="ctrl.targetBlur()"
+                       ng-blur="ctrl.targetBlur('filterName')"
                 />
             </div>
         </div>
@@ -163,13 +163,13 @@
                 <label class="gf-form-label query-keyword width-10">
                     {{ param.displayName }}
                 </label>
-                <input type="text"
+                <input type="text" ng-required="param.required"
                        class="gf-form-input width-18"
                        ng-model="ctrl.target.filterParameters[param.key]"
                        spellcheck='false'
                        placeholder="{{ param.default != null ? param.default : '' }}"
                        data-min-length=0 data-items=100
-                       ng-blur="targetBlur()"
+                       ng-blur="ctrl.targetBlur(param.key, param.required)"
                 >
                 <div class="help-block">
                     {{ param.description }}
@@ -183,13 +183,13 @@
             <label class="gf-form-label query-keyword width-10">
                 Label <i class="fa fa-font"></i>
             </label>
-            <input type="text"
+            <input type="text" ng-required="ctrl.target.type === 'expression'"
                    class="gf-form-input"
                    ng-model="ctrl.target.label"
                    spellcheck='false'
                    placeholder="series label"
                    data-min-length=0 data-items=100
-                   ng-blur="ctrl.targetBlur()"
+                   ng-blur="ctrl.targetBlur('label', (ctrl.target.type === 'expression') ? true : false)"
             />
         </div>
     </div>

--- a/src/spec/test-main.js
+++ b/src/spec/test-main.js
@@ -10,6 +10,9 @@ prunk.mock('app/plugins/sdk', {
   QueryCtrl: null,
   loadPluginCss: () => {}
 });
+prunk.mock('app/core/app_events', {
+  appEvents: null
+});
 
 // Setup jsdom
 // Required for loading angularjs


### PR DESCRIPTION
- JIRA: https://issues.opennms.org/browse/HELM-71

This is a new attempt at fixing the behaviour of validateTarget(), updated to work with Helm 2.0.

This commit displays the error messages from validateTarget() to the user, instead of silently submitting API requests that are expected to fail:
![error message](https://user-images.githubusercontent.com/1952603/43361859-8242f320-92dc-11e8-9f3d-47a831bbbfef.png)

The commit also marks relevant input elements as required, which some browsers may visualise to the user:
![required input](https://user-images.githubusercontent.com/1952603/43361860-8549f83e-92dc-11e8-9f21-73a1e155700f.png)