### PR TITLE
HELM-62: make "Severity" a column type

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,6 +23,7 @@ public/css/*.min.css
 
 # Editor junk
 *.sublime-workspace
+.vscode/
 *.swp
 .idea/
 *.iml

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ ARG GRAFANA_VERSION="latest"
 FROM grafana/grafana:${GRAFANA_VERSION}
 
 ARG OPENNMS_HELM_VERSION="bleeding"
-ARG OPENNMS_HELM_PKG="opennms-helm_2.0.1-SNAPSHOT.tar.gz"
+ARG OPENNMS_HELM_PKG="opennms-helm_3.0.0-SNAPSHOT.tar.gz"
 
 LABEL maintainer "Ronny Trommer <ronny@opennms.org>"
 

--- a/README.md
+++ b/README.md
@@ -54,6 +54,16 @@ We use the Helm project in our [JIRA](https://issues.opennms.org/projects/HELM) 
 
 ## Changelog
 
+### v3.0.0
+
+- BREAKING CHANGE: "Severity" in the Alarm Table is now a normal column, rather than a "Severity icons"
+  check box in the config options; when upgrading, you will need to add the column with type `severity`
+  into existing alarm table panels
+- Added support for Situations (correlated alarms), including sending feedback on alarm correlations
+- Added support for overriding time intervals and max datapoints
+- Improved error messages for incomplete or invalid queries
+- Added additional transforms for flow data (`toBits`, `onlyIngress`, `onlyEgress`)
+
 ### v2.0.0
 
 - Added a new datasource for querying flow data from OpenNMS

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "opennms-helm",
-  "version": "2.0.1-SNAPSHOT",
+  "version": "3.0.0-SNAPSHOT",
   "description": "A PM/FM console for Grafana",
   "scripts": {
     "build": "grunt",

--- a/src/panels/alarm-table/column_options.html
+++ b/src/panels/alarm-table/column_options.html
@@ -47,6 +47,19 @@
                 <gf-form-switch class="gf-form" label-class="width-8" ng-if="style.type === 'string'" label="Sanitize HTML" checked="style.sanitize" change="editor.render()"></gf-form-switch>
             </div>
 
+            <div ng-if="style.type === 'severity'">
+                <div class="gf-form">
+                    <label class="gf-form-label width-8">Display As</label>
+                    <div class="gf-form-select-wrapper width-10">
+                        <select class="gf-form-input" ng-model="style.displayAs" ng-change="editor.render()">
+                            <option value="icon">Icon</option>
+                            <option value="label">Label</option>
+                            <option value="labelCaps">Label (UC)</option>
+                        </select>
+                        </div>
+                </div>
+            </div>
+
             <div ng-if="style.type === 'number'">
                 <div class="gf-form">
                     <label class="gf-form-label width-8">Unit</label>

--- a/src/panels/alarm-table/column_options.js
+++ b/src/panels/alarm-table/column_options.js
@@ -25,6 +25,7 @@ export class ColumnOptionsCtrl {
       {text: 'Number', value: 'number'},
       {text: 'String', value: 'string'},
       {text: 'Date', value: 'date'},
+      {text: 'Severity', value:'severity'},
       {text: 'Hidden', value: 'hidden'}
     ];
     this.fontSizes = ['80%', '90%', '100%', '110%', '120%', '130%', '150%', '160%', '180%', '200%', '220%', '250%'];

--- a/src/panels/alarm-table/editor.html
+++ b/src/panels/alarm-table/editor.html
@@ -48,6 +48,5 @@
     <div class="section gf-form-group">
         <h5 class="section-heading">Alarms</h5>
         <gf-form-switch class="gf-form" label-class="width-10" switch-class="max-width-6" label="Style with severity" checked="editor.panel.severity" on-change="editor.render()"></gf-form-switch>
-        <gf-form-switch class="gf-form" label-class="width-10" switch-class="max-width-6" label="Severity icons" checked="editor.panel.severityIcons" on-change="editor.render()"></gf-form-switch>
     </div>
 </div>

--- a/src/panels/alarm-table/module.html
+++ b/src/panels/alarm-table/module.html
@@ -4,7 +4,6 @@
         <table class="table-panel-table dense-table-panel-table alarm-table">
             <thead>
             <tr>
-                <th ng-if="ctrl.panel.severityIcons"></th>
                 <th ng-repeat="col in ctrl.table.columns" ng-hide="col.hidden">
                     <div class="table-panel-table-header-inner pointer" ng-click="ctrl.toggleColumnSort(col, $index)">
                         {{col.title}}

--- a/src/panels/alarm-table/module.js
+++ b/src/panels/alarm-table/module.js
@@ -37,6 +37,11 @@ class AlarmTableCtrl extends MetricsPanelCtrl {
       showHeader: true,
       styles: [
         {
+          type: 'severity',
+          pattern: 'Severity',
+          displayAs: 'icon',
+        },
+        {
           type: 'date',
           pattern: '/.*Time/', // Render all "* Time" columns as date, e.g. "Last Event Time", "First Event Time", etc.
           dateFormat: 'YYYY-MM-DD HH:mm:ss',
@@ -73,16 +78,17 @@ class AlarmTableCtrl extends MetricsPanelCtrl {
         }
       ],
       columns: [
+          {text: 'Severity'},
           {text: 'UEI'},
           {text: 'Log Message'},
           {text: 'Node Label'},
           {text: 'Count'},
-          {text: 'Last Event Time',}],
+          {text: 'Last Event Time'},
+        ],
       scroll: false, // disable scrolling as the actions popup is not working properly otherwise
       fontSize: '100%',
       sort: {col: 0, desc: true},
-      severity: true,
-      severityIcons: true
+      severity: true
     };
 
     this.pageIndex = 0;

--- a/src/panels/alarm-table/sass/table.scss
+++ b/src/panels/alarm-table/sass/table.scss
@@ -1,7 +1,29 @@
 @import "ionicons";
 
+.table-panel-table {
+  td:first-child {
+    &.text-center {
+      padding-left: .225em;
+      padding-right: .225em;
+    }
+  }
+}
+
+.dense-table-panel-table {
+  td:first-child {
+    padding-left: .75em;
+    &.text-center {
+      padding-left: .375em;
+      padding-right: .375em;
+    }
+  }
+}
+
 .dense-table-panel-table td {
   padding: .25em 0 .25em 0.75em;
+  .text-center {
+    padding: .25em 0 .25em 0;
+  }
 }
 
 .dense-table-panel-table td p {
@@ -15,8 +37,10 @@
 }
 
 .severity-icon {
-  padding-left: 5px !important;
-  padding-right: 5px !important;
+  padding-left: 10px;
+  margin-left: -5px;
+  padding-right: 10px;
+  margin-right: -5px;
 }
 
 $cell-font-weight: 600;

--- a/src/panels/alarm-table/table_model.js
+++ b/src/panels/alarm-table/table_model.js
@@ -1,3 +1,4 @@
+import {Model} from '../../opennms';
 
 export class TableModel {
   constructor() {
@@ -6,14 +7,33 @@ export class TableModel {
     this.type = 'table';
   }
 
+  severityForLabel(label) {
+    const sev = Model.Severities[label];
+    if (sev) {
+      return sev.id;
+    } else {
+      console.warn('Unable to determine severity for "' + label + '".');
+      return -1;
+    }
+  }
+
   sort(options) {
     if (options.col === null || this.columns.length <= options.col) {
       return;
     }
 
+    var self = this;
     this.rows.sort(function(a, b) {
-      a = a[options.col];
-      b = b[options.col];
+      const colInfo = self.columns[options.col];
+
+      if (colInfo.style.type === 'severity') {
+        a = self.severityForLabel(a[options.col]);
+        b = self.severityForLabel(b[options.col]);
+      } else {
+        a = a[options.col];
+        b = b[options.col];
+      }
+
       if (a < b) {
         return -1;
       }

--- a/src/panels/alarm-table/table_model.js
+++ b/src/panels/alarm-table/table_model.js
@@ -26,7 +26,7 @@ export class TableModel {
     this.rows.sort(function(a, b) {
       const colInfo = self.columns[options.col];
 
-      if (colInfo.style.type === 'severity') {
+      if (colInfo && colInfo.style && colInfo.style.type === 'severity') {
         a = self.severityForLabel(a[options.col]);
         b = self.severityForLabel(b[options.col]);
       } else {


### PR DESCRIPTION
This PR changes the `TableRenderer` to treat "severity" as a first-class type, like number or date columns.

* bump version to 3.0.0 because of breaking config change
* remove config option for "Severity icon"
* add column type "severity"
* add support for configuring severity column type (icon, label, upper-case label)
* add support for sorting the severity column
* add a mouseover to the severity icon