### PR TITLE
HELM-99: make severity color coding column or row

### DIFF
--- a/src/panels/alarm-table/column_options.html
+++ b/src/panels/alarm-table/column_options.html
@@ -110,6 +110,9 @@
                 </div>
             </div>
             <div class="gf-form-inline">
+                <gf-form-switch class="gf-form" label-class="width-8" switch-class="max-width-8" label="Center" checked="style.center" on-change="editor.render()"></gf-form-switch>
+            </div>
+            <div class="gf-form-inline">
                 <gf-form-switch class="gf-form" label-class="width-8" switch-class="max-width-8" label="Clip" checked="style.clip" on-change="editor.render()"></gf-form-switch>
             </div>
         </div>

--- a/src/panels/alarm-table/editor.html
+++ b/src/panels/alarm-table/editor.html
@@ -47,6 +47,18 @@
 
     <div class="section gf-form-group">
         <h5 class="section-heading">Alarms</h5>
-        <gf-form-switch class="gf-form" label-class="width-10" switch-class="max-width-6" label="Style with severity" checked="editor.panel.severity" on-change="editor.render()"></gf-form-switch>
+        <!-- <gf-form-switch class="gf-form" label-class="width-10" switch-class="max-width-6" label="Style with severity" checked="editor.panel.severity" on-change="editor.render()"></gf-form-switch> -->
+        <div class="gf-form max-width-20">
+            <label class="gf-form-label width-10">Style with severity</label>
+            <div class="gf-form-select-wrapper width-8">
+                <select class="gf-form-input"
+                        ng-model="editor.panel.severity"
+                        ng-change="editor.render()">
+                    <option value="row">Row</option>
+                    <option value="column">Column</option>
+                    <option value="off">Off</option>
+                </select>
+            </div>
+        </div>
     </div>
 </div>

--- a/src/panels/alarm-table/editor.js
+++ b/src/panels/alarm-table/editor.js
@@ -17,6 +17,10 @@ export class TablePanelEditorCtrl {
     this.transformers = transformers;
     this.fontSizes = ['80%', '90%', '100%', '110%', '120%', '130%', '150%', '160%', '180%', '200%', '220%', '250%'];
 
+    if (this.panel.severity === true) {
+      this.panel.severity = 'row';
+    }
+
     this.addColumnSegment = uiSegmentSrv.newPlusButton();
   }
 

--- a/src/panels/alarm-table/renderer.js
+++ b/src/panels/alarm-table/renderer.js
@@ -152,11 +152,12 @@ export class TableRenderer {
     return this.formatters[colIndex] ? this.formatters[colIndex](value) : value;
   }
 
-  renderCell(columnIndex, value, addWidthHack = false) {
+  renderCell(columnIndex, value, addWidthHack, columnClasses) {
     value = this.formatColumnValue(columnIndex, value);
     let column = this.table.columns[columnIndex];
     let styles = {};
     let classes = column.classes || [];
+    classes = classes.concat(columnClasses);
 
     if (this.colorState.cell) {
       styles['background-color'] = this.colorState.cell;
@@ -276,7 +277,14 @@ export class TableRenderer {
       let severity = alarm.severity.label.toLowerCase();
 
       for (let i = 0; i < this.table.columns.length; i++) {
-        cellHtml += this.renderCell(i, row[i], y === startPos);
+        let columnClasses = [];
+        if (this.panel.severity === 'column') {
+          const col = this.table.columns[i];
+          if (col && col.style && col.style.type === 'severity') {
+            columnClasses.push(severity);
+          }
+        }
+        cellHtml += this.renderCell(i, row[i], y === startPos, columnClasses);
       }
 
       if (this.colorState.row) {
@@ -284,7 +292,7 @@ export class TableRenderer {
         this.colorState.row = null;
       }
 
-      if (this.panel.severity) {
+      if (this.panel.severity === true || this.panel.severity === 'row') {
         rowClasses.push(severity);
       }
 


### PR DESCRIPTION
This PR makes the color-coding for severity configurable to either be `Row` (the entire row, like the current impl when checked), `Column` (just any column with `type='severity'`), or `Off` (like the current impl, when unchecked).

This PR relies on changes made in https://github.com/OpenNMS/opennms-helm/pull/68