### PR TITLE
HELM-62: automatically upgrade from old severity config

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,9 +56,8 @@ We use the Helm project in our [JIRA](https://issues.opennms.org/projects/HELM) 
 
 ### v3.0.0
 
-- BREAKING CHANGE: "Severity" in the Alarm Table is now a normal column, rather than a "Severity icons"
-  check box in the config options; when upgrading, you will need to add the column with type `severity`
-  into existing alarm table panels
+- "Severity" in the Alarm Table is now a normal column, rather than a "Severity icons" check box in
+  the config options -- existing configs should be automatically upgraded
 - Added support for reordering columns in the alarm table
 - Added support for Situations (correlated alarms), including sending feedback on alarm correlations
 - Added support for overriding time intervals and max datapoints

--- a/src/panels/alarm-table/editor.js
+++ b/src/panels/alarm-table/editor.js
@@ -21,10 +21,6 @@ export class TablePanelEditorCtrl {
     this.srcIndex = undefined;
     this.destIndex = undefined;
 
-    if (this.panel.severity === true) {
-      this.panel.severity = 'row';
-    }
-
     this.addColumnSegment = uiSegmentSrv.newPlusButton();
     let editor = document.querySelectorAll('.editor-row')[0];
     for (const e of [ 'dragstart', 'dragover', 'dragleave', 'drop']) {

--- a/src/panels/alarm-table/module.js
+++ b/src/panels/alarm-table/module.js
@@ -109,6 +109,38 @@ class AlarmTableCtrl extends MetricsPanelCtrl {
     this.events.on('data-snapshot-load', this.onDataReceived.bind(this));
     this.events.on('init-edit-mode', this.onInitEditMode.bind(this));
 
+    if (this.panel.severity === true) {
+      this.panel.severity = 'row';
+    }
+
+    if (this.panel.severityIcons === true) {
+      delete this.panel.severityIcons;
+      if (this.panel.sort && this.panel.sort.col !== undefined) {
+        this.panel.sort.col++;
+      }
+      this.panel.styles.unshift({
+        type: 'severity',
+        pattern: 'Severity',
+        displayAs: 'icon'
+      });
+      this.panel.columns.unshift({
+        hidden: false,
+        text: 'Severity',
+        title: 'Severity',
+        style: {
+          type: 'severity',
+          pattern: 'Severity',
+          displayAs: 'icon'
+        }
+      });
+      if (this.table && this.table.rows) {
+        // put a placeholder value in until data refreshes
+        this.table.rows = this.table.rows.map((row) => {
+          row.unshift(undefined);
+        });
+      }
+    }
+
     self.refreshAppConfig();
   }
 


### PR DESCRIPTION
This is an additional PR relating to `HELM-62`, which automatically upgrades existing Helm 2.0 configs with `severityIcon=true` checked to their Helm 3.0 equivalent.

I confirmed by creating an alarm table with the box checked in Helm 2.0, then upgraded the plugin to 3.0 and reloaded.