### PR TITLE
HELM-73: make $node template variable work in alarm queries

### DIFF
--- a/src/datasources/fault-ds/datasource.js
+++ b/src/datasources/fault-ds/datasource.js
@@ -74,16 +74,29 @@ export class OpenNMSFMDatasource {
       const self = this;
       _.each(clauses, clause => {
         if (clause.restriction) {
-            if (clause.restriction instanceof API.NestedRestriction) {
-                self.substitute(clause.restriction.clauses, options);
-            } else if (clause.restriction.value) {
+            const restriction = clause.restriction;
+            if (restriction instanceof API.NestedRestriction) {
+                self.substitute(restriction.clauses, options);
+            } else if (restriction.value) {
                 // Range must be of type date, otherwise it is not parseable by the OpenNMS client
-                if (clause.restriction.value === '$range_from' || clause.restriction.value === "[[range_from]]") {
-                    clause.restriction.value = options.range.from;
-                } else if (clause.restriction.value === '$range_to' || clause.restriction.value === "[[range_to]]") {
-                    clause.restriction.value = options.range.to;
+                if (restriction.value === '$range_from' || restriction.value === "[[range_from]]") {
+                    restriction.value = options.range.from;
+                } else if (restriction.value === '$range_to' || restriction.value === "[[range_to]]") {
+                    restriction.value = options.range.to;
                 } else {
-                    clause.restriction.value = self.templateSrv.replace(clause.restriction.value, options.scopedVars);
+                    restriction.value = self.templateSrv.replace(restriction.value, options.scopedVars);
+                }
+                // Turn node criteria fs:fid into separate clauses
+                if (restriction.attribute === 'node' && restriction.value.indexOf(':') > 0) {
+                    if (restriction.comparator.id !== API.Comparators.EQ.id) {
+                        console.log('WARNING: Using a comparator other than EQ will probably not work as expected with a foreignSource:foreignId node criteria.');
+                    }
+                    const nodeCriteria = restriction.value.split(':');
+                    const replacement = new API.NestedRestriction(
+                        new API.Clause(new API.Restriction('node.foreignSource', restriction.comparator, nodeCriteria[0]), API.Operators.AND),
+                        new API.Clause(new API.Restriction('node.foreignId', restriction.comparator, nodeCriteria[1]), API.Operators.AND),
+                    );
+                    clause.restriction = replacement;
                 }
             }
         }

--- a/src/spec/fault_ds_datasource_spec.js
+++ b/src/spec/fault_ds_datasource_spec.js
@@ -905,6 +905,17 @@ describe("OpenNMS_FaultManagement_Datasource", function() {
                 expect(actualFilter.clauses[0].restriction.clauses[0].restriction.value).to.equal('FS');
                 expect(actualFilter.clauses[0].restriction.clauses[1].restriction.value).to.equal('FID');
             });
+
+            it ('should turn a node criteria ID restriction into a node.id clause', () => {
+                const filter = new API.Filter()
+                    .withClause(new API.Clause(new API.Restriction('node', API.Comparators.EQ, '1'), API.Operators.AND));
+
+                const actualFilter = ctx.datasource.buildQuery(filter, {});
+                expect(filter).not.to.equal(actualFilter);
+                expect(actualFilter.clauses.length).to.equal(1);
+                expect(actualFilter.clauses[0].restriction.attribute).to.equal('node.id');
+                expect(actualFilter.clauses[0].restriction.value).to.equal('1');
+            });
         });
     });
 

--- a/src/spec/fault_ds_datasource_spec.js
+++ b/src/spec/fault_ds_datasource_spec.js
@@ -894,6 +894,17 @@ describe("OpenNMS_FaultManagement_Datasource", function() {
                expect(actualFilter.clauses[0].restriction.clauses[1].restriction.value).to.equal(ctx.range_to);
 
             });
+
+            it ('should turn a node criteria fs:fid restriction into 2 separate clauses', () => {
+                const filter = new API.Filter()
+                    .withClause(new API.Clause(new API.Restriction('node', API.Comparators.EQ, 'FS:FID'), API.Operators.AND));
+
+                const actualFilter = ctx.datasource.buildQuery(filter, {});
+                expect(filter).not.to.equal(actualFilter);
+                expect(actualFilter.clauses.length).to.equal(1);
+                expect(actualFilter.clauses[0].restriction.clauses[0].restriction.value).to.equal('FS');
+                expect(actualFilter.clauses[0].restriction.clauses[1].restriction.value).to.equal('FID');
+            });
         });
     });
 


### PR DESCRIPTION
This PR fixes the `fault-ds` so it turns a `node=foreignSource:foreignId` criteria from a template variable into a separate set of criterias for foreign source and foreign ID.

Note: it does _not_ solve the (probably common) issue of wanting to multi-select nodes.  That will require additional work.