### PR TITLE
HELM-106: Improve naming and axis labels

### DIFF
--- a/src/dashboards/flow_deep_dive.json
+++ b/src/dashboards/flow_deep_dive.json
@@ -81,13 +81,16 @@
       },
       "id": 3,
       "legend": {
-        "avg": false,
+        "alignAsTable": true,
+        "avg": true,
         "current": false,
-        "max": false,
-        "min": false,
+        "max": true,
+        "min": true,
         "show": true,
+        "sort": "avg",
+        "sortDesc": true,
         "total": false,
-        "values": false
+        "values": true
       },
       "lines": true,
       "linewidth": 1,
@@ -369,13 +372,16 @@
           },
           "id": 2,
           "legend": {
-            "avg": false,
+            "alignAsTable": true,
+            "avg": true,
             "current": false,
-            "max": false,
-            "min": false,
+            "max": true,
+            "min": true,
             "show": true,
+            "sort": "avg",
+            "sortDesc": true,
             "total": false,
-            "values": false
+            "values": true
           },
           "lines": true,
           "linewidth": 1,
@@ -465,13 +471,16 @@
           },
           "id": 8,
           "legend": {
-            "avg": false,
+            "alignAsTable": true,
+            "avg": true,
             "current": false,
-            "max": false,
-            "min": false,
+            "max": true,
+            "min": true,
             "show": true,
+            "sort": "avg",
+            "sortDesc": true,
             "total": false,
-            "values": false
+            "values": true
           },
           "lines": true,
           "linewidth": 1,
@@ -589,13 +598,16 @@
           },
           "id": 5,
           "legend": {
-            "avg": false,
+            "alignAsTable": true,
+            "avg": true,
             "current": false,
-            "max": false,
-            "min": false,
+            "max": true,
+            "min": true,
             "show": true,
+            "sort": "avg",
+            "sortDesc": true,
             "total": false,
-            "values": false
+            "values": true
           },
           "lines": false,
           "linewidth": 1,

--- a/src/dashboards/flow_deep_dive.json
+++ b/src/dashboards/flow_deep_dive.json
@@ -63,7 +63,7 @@
       "id": 9,
       "panels": [],
       "repeat": null,
-      "title": "Traffic (Flows)",
+      "title": "Flow Interface Statistics",
       "type": "row"
     },
     {
@@ -142,7 +142,7 @@
       "thresholds": [],
       "timeFrom": null,
       "timeShift": null,
-      "title": "Traffic by Application",
+      "title": "Throughput by Application",
       "tooltip": {
         "shared": true,
         "sort": 0,
@@ -159,7 +159,7 @@
       "yaxes": [
         {
           "format": "Bps",
-          "label": null,
+          "label": "bytes/sec",
           "logBase": 1,
           "max": null,
           "min": null,
@@ -340,7 +340,7 @@
           "refId": "A"
         }
       ],
-      "title": "Traffic by Application",
+      "title": "Data Usage by Application",
       "transform": "table",
       "type": "table"
     },
@@ -417,7 +417,7 @@
           "thresholds": [],
           "timeFrom": null,
           "timeShift": null,
-          "title": "MIB-2 Traffic",
+          "title": "Interface Throughput",
           "tooltip": {
             "shared": true,
             "sort": 0,
@@ -434,7 +434,7 @@
           "yaxes": [
             {
               "format": "Bps",
-              "label": null,
+              "label": "bytes/sec",
               "logBase": 1,
               "max": null,
               "min": null,
@@ -526,7 +526,7 @@
           "thresholds": [],
           "timeFrom": null,
           "timeShift": null,
-          "title": "MIB-2 Errors and Discards",
+          "title": "Errors and Discards",
           "tooltip": {
             "shared": true,
             "sort": 0,
@@ -542,8 +542,8 @@
           },
           "yaxes": [
             {
-              "format": "Bps",
-              "label": null,
+              "format": "none",
+              "label": "packets/sec",
               "logBase": 1,
               "max": null,
               "min": null,
@@ -561,7 +561,7 @@
         }
       ],
       "repeat": null,
-      "title": "Traffic (SNMP via MIB-2)",
+      "title": "SNMP Interface Statistics",
       "type": "row"
     },
     {
@@ -642,7 +642,7 @@
           "thresholds": [],
           "timeFrom": null,
           "timeShift": null,
-          "title": "Traffic by Conversation (Top N)",
+          "title": "Throughput by Conversation (Top N)",
           "tooltip": {
             "shared": true,
             "sort": 0,
@@ -659,7 +659,7 @@
           "yaxes": [
             {
               "format": "Bps",
-              "label": null,
+              "label": "bytes/sec",
               "logBase": 1,
               "max": null,
               "min": null,
@@ -836,7 +836,7 @@
               "refId": "A"
             }
           ],
-          "title": "Traffic by Conversation (Top N)",
+          "title": "Data Usage by Conversation (Top N)",
           "transform": "table",
           "type": "table"
         }


### PR DESCRIPTION
Distinguish transferred bytes per second and total amount of transferred data in the given time frame by distinguish "Throughput" and "Data Usage". Added unit labels for "bytes/sec" in time series graphs for throughput. Additionally changed the Errors and Discards from SNMP MIB-2 to packets/sec referred to https://www.ietf.org/rfc/rfc1213.txt

Set legend as a table with min/max/avg and set default to sort avg descending to allow users to identify relevant throughput to filter.

* JIRA: https://issues.opennms.org/browse/HELM-106