### PR TITLE
HELM-105: handle multi-select variables

### DIFF
--- a/src/spec/fault_ds_datasource_spec.js
+++ b/src/spec/fault_ds_datasource_spec.js
@@ -912,6 +912,65 @@ describe("OpenNMS_FaultManagement_Datasource", function() {
                 expect(actualFilter.clauses[0].restriction.attribute).to.equal('node.id');
                 expect(actualFilter.clauses[0].restriction.value).to.equal('1');
             });
+
+            it ('should handle multi-select with 0 values selected', () => {
+                const filter = new API.Filter()
+                    .withClause(new API.Clause(new API.Restriction('severity', API.Comparators.EQ, '$severity'), API.Operators.AND));
+
+                ctx.templateSrv.init([{
+                    name: 'severity',
+                    multi: true,
+                    current: {
+                        value: []
+                    }
+                }]);
+
+                const actualFilter = ctx.datasource.buildQuery(filter, {});
+                expect(filter).not.to.equal(actualFilter);
+                expect(actualFilter.clauses.length).to.equal(1);
+                expect(actualFilter.clauses[0].restriction.clauses).not.to.equal(null);
+                expect(actualFilter.clauses[0].restriction.clauses.length).to.equal(0);
+            });
+
+            it ('should handle multi-select with 1 value selected', () => {
+                const filter = new API.Filter()
+                    .withClause(new API.Clause(new API.Restriction('severity', API.Comparators.EQ, '$severity'), API.Operators.AND));
+
+                ctx.templateSrv.init([{
+                    name: 'severity',
+                    multi: true,
+                    current: {
+                        value: ['NORMAL']
+                    }
+                }]);
+
+                const actualFilter = ctx.datasource.buildQuery(filter, {});
+                expect(filter).not.to.equal(actualFilter);
+                expect(actualFilter.clauses.length).to.equal(1);
+                expect(actualFilter.clauses[0].restriction.attribute).to.equal('severity');
+                expect(actualFilter.clauses[0].restriction.value).to.equal('NORMAL');
+            });
+
+            it ('should handle multi-select with 2 values selected', () => {
+                const filter = new API.Filter()
+                    .withClause(new API.Clause(new API.Restriction('severity', API.Comparators.EQ, '$severity'), API.Operators.AND));
+
+                ctx.templateSrv.init([{
+                    name: 'severity',
+                    multi: true,
+                    current: {
+                        value: ['NORMAL', 'WARNING']
+                    }
+                }]);
+
+                const actualFilter = ctx.datasource.buildQuery(filter, {});
+                expect(filter).not.to.equal(actualFilter);
+                expect(actualFilter.clauses.length).to.equal(1);
+                expect(actualFilter.clauses[0].restriction.clauses).not.to.equal(null);
+                expect(actualFilter.clauses[0].restriction.clauses.length).to.equal(2);
+                expect(actualFilter.clauses[0].restriction.clauses[0].restriction.value).to.equal('NORMAL');
+                expect(actualFilter.clauses[0].restriction.clauses[1].restriction.value).to.equal('WARNING');
+            });
         });
     });
 

--- a/src/spec/fault_ds_datasource_spec.js
+++ b/src/spec/fault_ds_datasource_spec.js
@@ -8,6 +8,8 @@ import {FilterCloner} from '../datasources/fault-ds/FilterCloner';
 import {OpenNMSFMDatasource as Datasource} from '../datasources/fault-ds/datasource'
 import {ClientDelegate} from '../lib/client_delegate';
 
+import {TemplateSrv} from './template_srv';
+
 describe("OpenNMS_FaultManagement_Datasource", function() {
     let uiSegmentSrv = {
         newSegment: function (value, type) {
@@ -752,7 +754,7 @@ describe("OpenNMS_FaultManagement_Datasource", function() {
             // Context initialization
             ctx.$q = Q;
             ctx.backendSrv = {};
-            ctx.templateSrv = {replace: (value, scopedVars) => value};
+            ctx.templateSrv = new TemplateSrv();
             ctx.uiSegmentSrv = uiSegmentSrv;
             ctx.contextSrv = {user: {login: "admin", email: "admin@opennms.org", name:"The Administrator"}};
             ctx.range_from = moment();
@@ -822,12 +824,6 @@ describe("OpenNMS_FaultManagement_Datasource", function() {
 
         describe('buildQuery', () => {
             it('should substitute scoped variables', () => {
-                // Mock the replace function
-                ctx.templateSrv.replace = (value, scopedVars) => {
-                    return value.replace(/\$variable1/g, scopedVars['variable1'].value)
-                        .replace(/\[\[variable1\]\]/g, scopedVars['variable1'].value);
-                };
-
                 // The filter with variables
                 const filter = new API.Filter()
                     .withClause(new API.Clause(new API.Restriction("key", API.Comparators.EQ, "$variable1"), API.Operators.AND))

--- a/src/spec/template_srv.js
+++ b/src/spec/template_srv.js
@@ -1,0 +1,136 @@
+import _ from 'lodash';
+
+export class TemplateSrv {
+  constructor() {
+    this.variables = [];
+    this.grafanaVariables = {};
+    this.index = {};
+    /*
+     * This regex matches 3 types of variable reference with an optional format specifier
+     * \$(\w+)                          $var1
+     * \[\[([\s\S]+?)(?::(\w+))?\]\]    [[var2]] or [[var2:fmt2]]
+     * \${(\w+)(?::(\w+))?}             ${var3} or ${var3:fmt3}
+    */
+    this.regex = /\$(\w+)|\[\[([\s\S]+?)(?::(\w+))?\]\]|\${(\w+)(?::(\w+))?}/g;
+  }
+
+  init(variables) {
+    this.variables = variables;
+    this.updateTemplateData();
+  }
+
+  updateTemplateData() {
+    this.index = {};
+
+    for (var i = 0; i < this.variables.length; i++) {
+      var variable = this.variables[i];
+
+      if (!variable.current || (!variable.current.isNone && !variable.current.value)) {
+        continue;
+      }
+
+      this.index[variable.name] = variable;
+    }
+  }
+
+  formatValue(value, format, variable) {
+    // for some scopedVars there is no variable
+    variable = variable || {};
+
+    if (typeof format === 'function') {
+      return format(value, variable, this.formatValue);
+    }
+
+    switch (format) {
+      case 'regex': {
+        throw new Error('not supported');
+      }
+      case 'lucene': {
+        throw new Error('not supported');
+      }
+      case 'pipe': {
+        if (typeof value === 'string') {
+          return value;
+        }
+        return value.join('|');
+      }
+      case 'distributed': {
+        throw new Error('not supported');
+      }
+      default: {
+        if (_.isArray(value)) {
+          return '{' + value.join(',') + '}';
+        }
+        return value;
+      }
+    }
+  }
+
+  getVariableName(expression) {
+    this.regex.lastIndex = 0;
+    var match = this.regex.exec(expression);
+    if (!match) {
+      return null;
+    }
+    return match[1] || match[2];
+  }
+
+  getAllValue(variable) {
+    if (variable.allValue) {
+      return variable.allValue;
+    }
+    var values = [];
+    for (var i = 1; i < variable.options.length; i++) {
+      values.push(variable.options[i].value);
+    }
+    return values;
+  }
+
+  replace(target, scopedVars, format) {
+    if (!target) {
+      return target;
+    }
+
+    var variable, systemValue, value;
+    this.regex.lastIndex = 0;
+
+    return target.replace(this.regex, (match, var1, var2, fmt2, var3, fmt3) => {
+      variable = this.index[var1 || var2 || var3];
+      format = fmt2 || fmt3 || format;
+      if (scopedVars) {
+        value = scopedVars[var1 || var2 || var3];
+        if (value) {
+          return this.formatValue(value.value, format, variable);
+        }
+      }
+    
+      if (!variable) {
+        return match;
+      }
+    
+      systemValue = this.grafanaVariables[variable.current.value];
+      if (systemValue) {
+        return this.formatValue(systemValue, format, variable);
+      }
+    
+      value = variable.current.value;
+      if (this.isAllValue(value)) {
+        value = this.getAllValue(variable);
+        // skip formating of custom all values
+        if (variable.allValue) {
+          return value;
+        }
+      }
+    
+      var res = this.formatValue(value, format, variable);
+      return res;
+    });
+  }
+
+  isAllValue(value) {
+    return value === '$__all' || (Array.isArray(value) && value[0] === '$__all');
+  }
+
+}
+
+export default new TemplateSrv();


### PR DESCRIPTION
This PR adds support for multi-select variables in the alarm table.  Tested with `node` and `severity` columns.