### PR TITLE
HELM-110: add managedObjectInstance and managedObjectType

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "babel-preset-es2015": "^6.24.1",
     "crypto-js": "^3.1.9-1",
     "lodash": "~4.17.4",
-    "opennms": "https://github.com/OpenNMS/opennms-js.git#3c5edf0a7ac3b69a0105d4c11c5852a027fd9442",
+    "opennms": "dev",
     "q": "^1.5.0"
   },
   "homepage": "https://github.com/OpenNMS/opennms-helm",

--- a/src/datasources/fault-ds/datasource.js
+++ b/src/datasources/fault-ds/datasource.js
@@ -285,6 +285,7 @@ export class OpenNMSFMDatasource {
             "Sticky ID", "Sticky Note", "Sticky Author", "Sticky Update Time", "Sticky Creation Time",
             "Journal ID", "Journal Note", "Journal Author", "Journal Update Time", "Journal Creation Time",
             "Is Situation", "Situation Alarm Count", "Affected Node Count",
+            "Managed Object Instance", "Managed Object Type",
             "Data Source"
         ];
 
@@ -360,6 +361,8 @@ export class OpenNMSFMDatasource {
                 alarm.relatedAlarms && alarm.relatedAlarms.length > 0 ? 'Y' : 'N',
                 alarm.relatedAlarms ? alarm.relatedAlarms.length.toFixed(0) : undefined,
                 alarm.affectedNodeCount ? alarm.affectedNodeCount.toFixed(0) : undefined,
+                alarm.managedObjectInstance ? alarm.managedObjectInstance : undefined,
+                alarm.managedObjectType ? alarm.managedObjectType : undefined,
 
                 // Data Source
                 self.name

--- a/src/panels/alarm-table/alarm_details.html
+++ b/src/panels/alarm-table/alarm_details.html
@@ -34,8 +34,8 @@
                     <td ng-bind-html="alarm.logMessage"></td>
                 </tr>
                 <tr>
-                    <td>Description</td>
-                    <td ng-bind-html="alarm.description"></td>
+                    <td style="vertical-align: text-top">Description</td>
+                    <td style="white-space: normal" ng-bind-html="alarm.description"></td>
                 </tr>
                 <tr ng-if="alarm.operatorInstructions">
                     <td>Operator Instructions</td>
@@ -58,6 +58,14 @@
                 <tr>
                     <td>Reduction Key</td>
                     <td>{{alarm.reductionKey}}</td>
+                </tr>
+                <tr ng-if="alarm.managedObjectInstance">
+                    <td>Managed Object Instance</td>
+                    <td>{{alarm.managedObjectInstance}}</td>
+                </tr>
+                <tr ng-if="alarm.managedObjectType">
+                    <td>Managed Object Type</td>
+                    <td>{{alarm.managedObjectType}}</td>
                 </tr>
             </table>
         </div>

--- a/src/spec/fault_ds_datasource_spec.js
+++ b/src/spec/fault_ds_datasource_spec.js
@@ -837,12 +837,12 @@ describe("OpenNMS_FaultManagement_Datasource", function() {
                     }
                 };
 
-                const substituedFilter = ctx.datasource.buildQuery(filter, options);
+                const substitutedFilter = ctx.datasource.buildQuery(filter, options);
 
                 // Verify
-                expect(substituedFilter.clauses[0].restriction.value).to.equal("dummy-value");
-                expect(substituedFilter.clauses[1].restriction.value).to.equal("Hello this is my dummy-value");
-                expect(substituedFilter.clauses[2].restriction.value).to.equal("value3");
+                expect(substitutedFilter.clauses[0].restriction.value).to.equal("dummy-value");
+                expect(substitutedFilter.clauses[1].restriction.value).to.equal("Hello this is my dummy-value");
+                expect(substitutedFilter.clauses[2].restriction.value).to.equal("value3");
             });
 
             it('should substitude $range_from and $range_to accordingly', () => {
@@ -864,11 +864,11 @@ describe("OpenNMS_FaultManagement_Datasource", function() {
                     .withClause(new API.Clause(new API.Restriction("key4", API.Comparators.EQ, "[[range_to]]"), API.Operators.AND));
 
                 // Build query and verify
-                const substituedFilter = ctx.datasource.buildQuery(filter, options);
-                expect(substituedFilter.clauses[0].restriction.value).to.equal(ctx.range_from);
-                expect(substituedFilter.clauses[1].restriction.value).to.equal(ctx.range_to);
-                expect(substituedFilter.clauses[2].restriction.value).to.equal(ctx.range_from);
-                expect(substituedFilter.clauses[3].restriction.value).to.equal(ctx.range_to);
+                const substitutedFilter = ctx.datasource.buildQuery(filter, options);
+                expect(substitutedFilter.clauses[0].restriction.value).to.equal(ctx.range_from);
+                expect(substitutedFilter.clauses[1].restriction.value).to.equal(ctx.range_to);
+                expect(substitutedFilter.clauses[2].restriction.value).to.equal(ctx.range_from);
+                expect(substitutedFilter.clauses[3].restriction.value).to.equal(ctx.range_to);
             });
 
             it ('should include $range_from and $range_to when building the query', () => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -2629,9 +2629,9 @@ onetime@^1.0.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/onetime/-/onetime-1.1.0.tgz#a1f7838f8314c516f05ecefcbc4ccfe04b4ed789"
 
-"opennms@https://github.com/OpenNMS/opennms-js.git#3c5edf0a7ac3b69a0105d4c11c5852a027fd9442":
-  version "1.2.3-SNAPSHOT"
-  resolved "https://github.com/OpenNMS/opennms-js.git#3c5edf0a7ac3b69a0105d4c11c5852a027fd9442"
+opennms@dev:
+  version "1.2.3-snapshot.develop.126"
+  resolved "https://registry.yarnpkg.com/opennms/-/opennms-1.2.3-snapshot.develop.126.tgz#085c1986a5a6f0e22d1a23cc9db1c3bdf449e270"
   dependencies:
     axios "^0.16.1"
     cli-table2 "^0.2.0"


### PR DESCRIPTION
This PR adds the `managedObjectInstance` and `managedObjectType` properties to the fault datasource, which allows you to use them as columns and also adds them to the "Alarm Details" popup.

It also includes a typo fix.  ;)