### PR TITLE
HELM-121: additional layout/theme fixes

### DIFF
--- a/src/panels/alarm-table/alarm_details.html
+++ b/src/panels/alarm-table/alarm_details.html
@@ -110,27 +110,30 @@
                     <th>Log Message</th>
                     <th ng-if="editFeedback" colspan="2" class="text-center">Correlation Feedback</th>
                 </thead>
-                <tbody class="severity">
-                    <tr ng-repeat="summary in relatedAlarms" ng-class="!summary.isHeader &amp;&amp; (severity === true || severity === 'row')? summary.severity.toLowerCase() : ''">
-                        <td colspan="{{editFeedback? 5 : 3}}" ng-if="summary.isHeader" class="alarm-details-spacer">
-                            <div class="alarm-details-header node-header">
-                                {{summary.nodeLabel}}
-                            </div>
-                        </td>
-                        <td ng-if="!summary.isHeader" ng-class="(severity === 'column')? summary.severity.toLowerCase() : ''">
+                <tbody ng-repeat-start="node in relatedAlarms">
+                    <tr class="alarm-details-node-spacer"><td colspan="{{editFeedback? 5 : 3 }}"><!-- {{node.label + ' / ' + node.$index}} --></td></tr>
+                </tbody>
+                <tbody ng-repeat-end class="severity" ng-class="node.label !== ''? 'alarm-details-node-group' : ''">
+                    <tr class="alarm-details-node-header">
+                        <td colspan="{{editFeedback? 5 : 3 }}"><span class="alarm-details-node-label">{{node.label}}</span></td>
+                    </tr>
+                    <tr ng-repeat="summary in node.alarms" ng-class="(severity === true || severity === 'row') ? summary.severity.toLowerCase() : ''">
+                        <td ng-class="(severity === 'column')? summary.severity.toLowerCase() : ''">
                             <a href="{{detailsLink}}={{summary.id}}" target="_blank">
                                 <i class="fa fa-external-link"></i>
                             </a>
                         </td>
-                        <td ng-if="!summary.isHeader" severity>{{summary.label}}</td>
-                        <td ng-if="!summary.isHeader" severity ng-bind-html="summary.logMessage"></td>
-                        <td ng-if="!summary.isHeader &amp;&amp; editFeedback" class="feedback-button" ng-click="ctrl.markCorrect(summary.reductionKey)">
+                        <td severity>{{summary.label}}</td>
+                        <td severity ng-bind-html="summary.logMessage"></td>
+                        <td ng-if="editFeedback" class="feedback-button" ng-click="ctrl.markCorrect(summary.reductionKey)">
                             <img ng-src="{{ctrl.detailFeedbackOkayButton(summary.reductionKey)}}" alt="Correct" height="22" width="22" />
                         </td>
-                        <td ng-if="!summary.isHeader &amp;&amp; editFeedback" class="feedback-button" ng-click="ctrl.markIncorrect(summary.reductionKey)">
+                        <td ng-if="editFeedback" class="feedback-button" ng-click="ctrl.markIncorrect(summary.reductionKey)">
                             <img ng-src="{{ctrl.detailFeedbackIncorrectButton(summary.reductionKey)}}" alt="Incorrect" height="22" width="22" />
                         </td>
                     </tr>
+                </tbody>
+                <tbody class="severity">
                     <tr ng-if="editFeedback">
                         <td colspan="3" class="text-right">Tally</td>
                         <td class="text-center feedback-button">{{feedbackCorrectCount}}</td>

--- a/src/panels/alarm-table/alarm_details.js
+++ b/src/panels/alarm-table/alarm_details.js
@@ -28,21 +28,20 @@ export class AlarmDetailsCtrl {
     $scope.source = $scope.$parent.source;
 
     if ($scope.alarm.relatedAlarms && $scope.alarm.relatedAlarms.length > 0) {
-      $scope.relatedAlarms = angular.copy($scope.alarm.relatedAlarms)
-        .sort((a, b) => compareStrings(a.nodeLabel, b.nodeLabel))
-        .reduce((acc, cur, idx, src) => {
-          const ret = acc;
-          const current = cur.nodeLabel;
-          const prev = idx === 0? undefined : src[idx-1].nodeLabel;
-          if (current !== prev) {
-            ret.push({
-              nodeLabel: current,
-              isHeader: true
-            });
-          }
-          ret.push(src[idx]);
-          return ret;
-        }, []);
+      const related = {};
+      $scope.alarm.relatedAlarms.forEach(alarm => {
+        const label = (alarm.nodeLabel === undefined || alarm.nodeLabel === null)? '' : alarm.nodeLabel;
+        if (!related[label]) {
+          related[label] = [];
+        }
+        related[label].push(alarm);
+      });
+      $scope.relatedAlarms = Object.keys(related).sort(compareStrings).map((label) => {
+        return {
+          label: label,
+          alarms: related[label]
+        };
+      });
     }
 
     // Feedback Counts

--- a/src/panels/alarm-table/module.js
+++ b/src/panels/alarm-table/module.js
@@ -401,7 +401,7 @@ class AlarmTableCtrl extends MetricsPanelCtrl {
 
     clearTimeout(alarmClick.timeout);
     alarmClick.timeout = setTimeout(() => {
-      if (self.clicks[alarmId].lastClick === clickTime) {
+      if (self.clicks[alarmId] && self.clicks[alarmId].lastClick === clickTime) {
         if (thisEvent.button === 2) {
           // right click
           self.getContextMenu(thisEvent, source, alarmId);
@@ -441,7 +441,9 @@ class AlarmTableCtrl extends MetricsPanelCtrl {
       };
       self.scheduleClickCheck(thisEvent, source, alarmId, now);
     }
-    self.clicks[alarmId].lastClick = now;
+    if (self.clicks[alarmId]) {
+      self.clicks[alarmId].lastClick = now;
+    }
   }
 
   onSingleClick($event, source, alarmId) {

--- a/src/panels/alarm-table/sass/colors.scss
+++ b/src/panels/alarm-table/sass/colors.scss
@@ -1,3 +1,18 @@
 $cell-dark-color: #000;
 $cell-light-color: #fff;
 
+/* taken from grafana _variables.scss */
+
+$dark-1: #141414;
+$dark-2: #1f1f20;
+$dark-3: #262628;
+$dark-4: #333333;
+$dark-5: #444444;
+
+$gray-1: #555555;
+$gray-2: #8e8e8e;
+$gray-3: #b3b3b3;
+$gray-4: #d8d9da;
+$gray-5: #ececec;
+$gray-6: #f4f5f8;
+$gray-7: #fbfbfb;

--- a/src/panels/alarm-table/sass/table.dark.scss
+++ b/src/panels/alarm-table/sass/table.dark.scss
@@ -1,9 +1,17 @@
 @import "colors";
 
 $cell-text-color: $cell-light-color;
-$cell-border-color: #171819;
+$cell-border-color: $dark-2;
 
 $selected-cell-no-severity-background-color: darkblue;
 $selected-cell-border-color: lightblue;
+
+$alarm-node-group-bg: rgb(22, 23, 25); // grafana $page-bg
+$alarm-node-group-border-color: $dark-4; // grafana $page-header-border-color
+$alarm-node-group-shadow: inset 0px -4px 14px $dark-2; // grafana $page-header-shadow
+
+$alarm-details-border-color: $dark-1;
+
+$alarm-details-header: linear-gradient(135deg, #2f2f32, #262628); // from grafana _variables.dark.scss
 
 @import "table";

--- a/src/panels/alarm-table/sass/table.light.scss
+++ b/src/panels/alarm-table/sass/table.light.scss
@@ -1,9 +1,17 @@
 @import "colors";
 
 $cell-text-color: $cell-dark-color;
-$cell-border-color: #f7f8fa; /* $gray-7 in Grafana's _variables.light.scss */
+$cell-border-color: $gray-7;
 
 $selected-cell-no-severity-background-color: lightblue;
 $selected-cell-border-color: darkblue;
+
+$alarm-node-group-bg: transparent;
+$alarm-node-group-border-color: $gray-4; // grafana $page-header-border-color
+$alarm-node-group-shadow: inset 0px -3px 10px $gray-6; // grafana $page-header-shadow
+
+$alarm-details-border-color: $gray-6;
+
+$alarm-details-header: linear-gradient(135deg, $gray-6, $gray-5); // from grafana _variables.light.scss
 
 @import "table";

--- a/src/panels/alarm-table/sass/table.scss
+++ b/src/panels/alarm-table/sass/table.scss
@@ -291,10 +291,39 @@ $details-header-font-weight: 500;
     font-weight: $details-header-font-weight;
   }
 
-  .alarm-details-spacer {
-    padding: 1rem 0 0 0 !important;
-    border: 0;
-    outline: 0;
+  tbody {
+    &.alarm-details-node-group {
+      border: 0 !important;
+      border-image-width: 0 !important;
+      background-color: $alarm-node-group-bg;
+      outline: 1px solid $alarm-node-group-border-color !important;
+      box-shadow: $alarm-node-group-shadow !important;
+    }
+    .alarm-details-node-header {
+      border: 0 !important;
+      border-image-width: 0 !important;
+      pointer-events: none;
+    }
+    .alarm-details-node-spacer {
+      border: 0 !important;
+      border-image-width: 0 !important;
+      pointer-events: none;
+      height: 1rem;
+    }
+  }
+
+  tr {
+    border-left: 2px solid $alarm-details-border-color;
+    border-right: 2px solid $alarm-details-border-color;
+
+    td {
+      border: 2px solid $alarm-details-border-color;
+
+      &:not(:first-child):not(:last-child) {
+        border-left: 2px solid $alarm-details-border-color;
+        border-right: 2px solid $alarm-details-border-color;
+      }
+    }
   }
 
   .alarm-details-header {
@@ -302,12 +331,13 @@ $details-header-font-weight: 500;
     font-weight: $details-header-font-weight;
     padding: .125rem;
     margin: 0;
-    background: linear-gradient(135deg,#2f2f32,#262628);
-    border-top: 2px solid #171819;
-    border-bottom:2px solid #171819;
+    background: $alarm-details-header;
+    border-top: 2px solid $cell-border-color;
+    border-bottom:2px solid $cell-border-color;
 
     &.node-header, th {
       padding-left: .75em !important;
     }
   }
+
 }

--- a/src/plugin.json
+++ b/src/plugin.json
@@ -24,7 +24,7 @@
       {"name": "Metrics", "path": "img/Helm_Screenshot_Metrics.png"},
       {"name": "Performance Data Source", "path": "img/Helm_Screenshot_Performance_Data_Source.png"}
     ],
-    "version": "2.0.1-SNAPSHOT",
+    "version": "3.0.0-SNAPSHOT",
     "updated": "2018-07-03"
   },
   "includes": [


### PR DESCRIPTION
This PR introduces a thin box around grouped node alarms in the alarm details view, to resolve feedback on the issue.  It also fixes a couple of other tiny layout/color bugs I found while working on the issue.

<img width="750" alt="screen shot 2019-01-08 at 11 51 54 am" src="https://user-images.githubusercontent.com/89252/50846238-ae046580-133c-11e9-8588-f98d847aa132.png">
<img width="749" alt="screen shot 2019-01-08 at 11 52 00 am" src="https://user-images.githubusercontent.com/89252/50846241-b197ec80-133c-11e9-9f5d-99f8c6862f2c.png">
<img width="750" alt="screen shot 2019-01-08 at 11 51 27 am" src="https://user-images.githubusercontent.com/89252/50846245-b5c40a00-133c-11e9-849a-16be4a18f4a4.png">
<img width="750" alt="screen shot 2019-01-08 at 11 51 34 am" src="https://user-images.githubusercontent.com/89252/50846250-b8266400-133c-11e9-9aaf-5e64d09749a8.png">
