### PR TITLE
HELM-84: support formatting of values from `nodeFilter` and `nodeResources`

### DIFF
--- a/.jshintrc
+++ b/.jshintrc
@@ -1,0 +1,4 @@
+{
+  "esversion": 6,
+  "expr": true
+}

--- a/src/datasources/perf-ds/function_formatter.js
+++ b/src/datasources/perf-ds/function_formatter.js
@@ -1,0 +1,143 @@
+const FUNCTION_MATCH = /(\w+)\(([^\)]*)\)/g;
+const ARGUMENT_MATCH = /\s*,\s*/;
+
+export class FunctionFormatter {
+    static findFunctions(label) {
+        let match, ret = [];
+        while ((match = FUNCTION_MATCH.exec(label)) !== null) {
+            const args = FunctionFormatter.getArguments(match[2]);
+            ret.push({
+                name: match[1],
+                arguments: FunctionFormatter.getArguments(match[2])
+            });
+        }
+        return ret;
+    }
+
+    static getArguments(args) {
+        const argsString = args === null? '' : args.trim();
+        if (argsString.length === 0) {
+            return [];
+        }
+        const split = argsString.split(ARGUMENT_MATCH);
+        return Array.isArray(split) ? split : [split];
+    }
+
+    static replace(label, replacements) {
+        let match;
+        let ret = label;
+        while ((match = FUNCTION_MATCH.exec(label)) !== null) {
+            const func = match[1],
+                args = FunctionFormatter.getArguments(match[2]);
+            if (replacements.hasOwnProperty(func)) {
+                const result = replacements[func].apply(replacements[func], args);
+                ret = ret.replace(match[0], result);
+            } else {
+                console.warn('LabelFormatter.replace: unhandled function ' + func);
+            }
+        }
+        return ret;
+    }
+    static format(label, metadata) {
+        return FunctionFormatter.replace(label, {
+            nodeToLabel: (nodeCriteria) => {
+                const node = FunctionFormatter._getNodeFromCriteria(metadata, nodeCriteria);
+                if (node) {
+                    return node.label;
+                }
+                return nodeCriteria;
+            },
+            resourceToLabel: (criteriaOrResourceId, partialResourceId) => {
+                const resource = FunctionFormatter._getResource(metadata, criteriaOrResourceId, partialResourceId);
+                if (resource) {
+                    return resource.label;
+                }
+                return partialResourceId ? [criteriaOrResourceId, partialResourceId].join('.') : criteriaOrResourceId;
+            },
+            resourceToName: (criteriaOrResourceId, partialResourceId) => {
+                const resource = FunctionFormatter._getResource(metadata, criteriaOrResourceId, partialResourceId);
+                if (resource) {
+                    return resource.name;
+                }
+                return partialResourceId ? [criteriaOrResourceId, partialResourceId].join('.') : criteriaOrResourceId;
+            },
+            resourceToInterface: (criteriaOrResourceId, partialResourceId) => {
+                const resource = FunctionFormatter._getResource(metadata, criteriaOrResourceId, partialResourceId);
+                if (resource) {
+                    let match = resource.name.match(/^(\w+)/);
+                    if (!match) {
+                        match = resource.label.match(/^(\w+)/);
+                    }
+                    if (match) {
+                        return match[1];
+                    }
+                }
+                return partialResourceId ? [criteriaOrResourceId, partialResourceId].join('.') : criteriaOrResourceId;
+            }
+        });
+    }
+
+    static _getNodeFromCriteria(metadata, nodeCriteria) {
+        let nodeId, foreignSource, foreignId;
+        if (nodeCriteria && nodeCriteria.indexOf(':') > 0) {
+            [foreignSource, foreignId] = nodeCriteria.split(':');
+        } else {
+            nodeId = parseInt(nodeCriteria, 10);
+        }
+        return FunctionFormatter._getNodeFromMetadata(metadata, nodeId, foreignSource, foreignId);
+    }
+
+    static _getNodeFromMetadata(metadata, nodeId, foreignSource, foreignId) {
+        if (metadata && metadata.nodes) {
+            const ret = metadata.nodes.filter((node) => {
+                return (nodeId !== undefined && node.id === nodeId) ||
+                (foreignSource !== undefined && foreignId !== undefined &&
+                    node['foreign-source'] === foreignSource && node['foreign-id'] === foreignId);
+            })[0];
+            if (ret !== undefined) {
+                return ret;
+            }
+        }
+        //console.warn('Unable to locate node ' + [nodeId, foreignSource, foreignId].join(',') + ' in metadata.', metadata);
+        return null;
+    }
+
+    static _getResource(metadata, criteriaOrResourceId, partialResourceId) {
+        if (partialResourceId === undefined) {
+            for (const resource of metadata.resources) {
+                if (resource.id === criteriaOrResourceId) {
+                    return resource;
+                }
+            }
+        } else {
+            const node = FunctionFormatter._getNodeFromCriteria(metadata, criteriaOrResourceId);
+            if (node) {
+                const resource = FunctionFormatter._getResourceFromCriteria(metadata, partialResourceId, 'node[' + node['foreign-source'] + ':' + node['foreign-id'] + ']', 'node[' + node.id + ']');
+                if (resource) {
+                    return resource;
+                }
+            }
+        }
+        //console.warn('Unable to locate resource ' + [criteriaOrResourceId,partialResourceId].join('.') + ' in metadata.', metadata);
+        return null;
+    }
+
+    static _getResourceFromCriteria(metadata, resourceCriteria, ...nodeCriterias) {
+        if (metadata && metadata.resources) {
+            const ret = metadata.resources.filter((resource) => {
+                if (resource.id === resourceCriteria) return true;
+                for (const criteria of nodeCriterias.map(c => c + '.' + resourceCriteria)) {
+                    if (resource.id === criteria) {
+                        return true;
+                    }
+                }
+                return false;
+            })[0];
+            if (ret !== undefined) {
+                return ret;
+            }
+        }
+        //console.warn('Unable to locate resource ' + resourceCriteria + ' in metadata.', metadata);
+        return null;
+    }
+}

--- a/src/datasources/perf-ds/query_ctrl.js
+++ b/src/datasources/perf-ds/query_ctrl.js
@@ -35,8 +35,8 @@ export class OpenNMSQueryCtrl extends QueryCtrl {
           };
         });
     }, function (node) {
-      if (!_.isUndefined(node.foreignId) && !_.isNull(node.foreignId)
-        && !_.isUndefined(node.foreignSource) && !_.isNull(node.foreignSource)) {
+      if (!_.isUndefined(node.foreignId) && !_.isNull(node.foreignId) &&
+        !_.isUndefined(node.foreignSource) && !_.isNull(node.foreignSource)) {
         // Prefer fs:fid
         self.target.nodeId = node.foreignSource + ":" + node.foreignId;
       } else {
@@ -207,7 +207,7 @@ export class OpenNMSQueryCtrl extends QueryCtrl {
     } else if (this.target.type === QueryType.Filter) {
       if (targetId == 'filterName' && (!this.target.filter || !this.target.filter.name)) {
         return "You must select a filter.";
-      } else if (required && (!this.target.filterParameters || !targetId in this.target.filterParameters || !this.target.filterParameters[targetId])) {
+      } else if (required && (!this.target.filterParameters || !(targetId in this.target.filterParameters) || !this.target.filterParameters[targetId])) {
         return targetId + ' is a required field.';
       }
     }

--- a/src/spec/perf_ds_label_formatter_spec.js
+++ b/src/spec/perf_ds_label_formatter_spec.js
@@ -1,0 +1,200 @@
+import {FunctionFormatter} from "../datasources/perf-ds/function_formatter";
+
+const FUNCS = {
+    exclamationer: (arg) => {
+        return arg + '!!!';
+    },
+    insulter: (person, insult) => {
+        return person + ' is a total ' + insult + '!';
+    }
+};
+
+describe('OpenNMSPMDatasource :: LabelFormatter', () => {
+    describe('findFunctions()', () => {
+        it('find a simple function with no arguments', () => {
+            const found = FunctionFormatter.findFunctions('simpleFunction()');
+            expect(found).to.exist;
+            expect(found.length).to.equal(1);
+            expect(found).to.deep.equal([
+                {
+                    name: 'simpleFunction',
+                    arguments: []
+                }
+            ]);
+        });
+        it('find a simple function with one argument', () => {
+            const found = FunctionFormatter.findFunctions('simpleFunction(foo)');
+            expect(found).to.exist;
+            expect(found.length).to.equal(1);
+            expect(found).to.deep.equal([
+                {
+                    name: 'simpleFunction',
+                    arguments: ['foo']
+                }
+            ]);
+        });
+        it('find a simple function with many arguments', () => {
+            const found = FunctionFormatter.findFunctions('simpleFunction(foo, bar, baz)');
+            expect(found).to.exist;
+            expect(found.length).to.equal(1);
+            expect(found).to.deep.equal([
+                {
+                    name: 'simpleFunction',
+                    arguments: ['foo', 'bar', 'baz']
+                }
+            ]);
+        });
+        it('find multiple functions with arguments', () => {
+            const found = FunctionFormatter.findFunctions('simpleFunction(foo, bar, baz), anotherThing($nodes)');
+            expect(found).to.exist;
+            expect(found.length).to.equal(2);
+            expect(found).to.deep.equal([
+                {
+                    name: 'simpleFunction',
+                    arguments: ['foo', 'bar', 'baz']
+                },
+                {
+                    name: 'anotherThing',
+                    arguments: ['$nodes']
+                }
+            ]);
+        });
+    });
+
+    describe('replace()', () => {
+        it('do not replace an unmatched function', () => {
+            const res = FunctionFormatter.replace('unmatchedFunction()', {
+                simpleFunction: () => {
+                    return 'foo';
+                }
+            });
+            expect(res).to.equal('unmatchedFunction()');
+        });
+        it('replace a simple function without arguments', () => {
+            const res = FunctionFormatter.replace('simpleFunction()', {
+                simpleFunction: () => {
+                    return 'foo';
+                }
+            });
+            expect(res).to.equal('foo');
+        });
+        it('replace a simple function with an argument', () => {
+            const res = FunctionFormatter.replace('exclamationer(foo)', FUNCS);
+            expect(res).to.equal('foo!!!');
+        });
+        it('replace a simple function with multiple arguments', () => {
+            const res = FunctionFormatter.replace('insulter(Bob, jerk)', FUNCS);
+            expect(res).to.equal('Bob is a total jerk!');
+        });
+        it('replace multiple functions', () => {
+            const res = FunctionFormatter.replace('exclamationer(Hey)  insulter(Bob, jerk)', FUNCS);
+            expect(res).to.equal('Hey!!!  Bob is a total jerk!');
+        });
+    });
+
+    const metadata = {
+        "resources": [
+            {
+                "id": "node[situation-test:nodea].responseTime[127.0.0.1]",
+                "label": "127.0.0.1",
+                "name": "localhost",
+                "parent-id": "node[situation-test:nodea]",
+                "node-id": 1
+            },
+            {
+                "id": "node[situation-test:nodeb].responseTime[127.0.0.1]",
+                "label": "127.0.0.1",
+                "name": "localhost",
+                "parent-id": "node[situation-test:nodeb]",
+                "node-id": 2
+            },
+            {
+                "id": "node[situation-test:nodeb].interfaceSnmp[en0-000123456789]",
+                "label": "en0 (127.0.0.1, 304.2 Mbps)",
+                "name": "en0-000123456789",
+                "parent-id": "node[situation-test:nodeb]",
+                "node-id": 2
+            }
+        ],
+        "nodes": [
+            {
+                "id": 1,
+                "label": "ThisIsAVeryLongNodeLabel1",
+                "foreign-source": "situation-test",
+                "foreign-id": "nodea"
+            },
+            {
+                "id": 2,
+                "label": "ThisIsAVeryLongNodeLabel2",
+                "foreign-source": "situation-test",
+                "foreign-id": "nodeb"
+            }
+        ]
+    };
+
+    describe('format()', () => {
+        it('nodeToLabel(foreignSource:foreignId)', () => {
+            const res = FunctionFormatter.format('nodeToLabel(situation-test:nodea)', metadata);
+            expect(res).to.equal('ThisIsAVeryLongNodeLabel1');
+        });
+        it('nodeToLabel(nodeId)', () => {
+            const res = FunctionFormatter.format('nodeToLabel(1)', metadata);
+            expect(res).to.equal('ThisIsAVeryLongNodeLabel1');
+        });
+        it('nodeToLabel(invalid)', () => {
+            const res = FunctionFormatter.format('nodeToLabel(3)', metadata);
+            expect(res).to.equal('3');
+        });
+
+        it('resourceToLabel(resourceId)', () => {
+            const res = FunctionFormatter.format('resourceToLabel(node[situation-test:nodea].responseTime[127.0.0.1])', metadata);
+            expect(res).to.equal('127.0.0.1');
+        });
+        it('resourceToLabel(situation-test:nodea, responseTime[127.0.0.1])', () => {
+            const res = FunctionFormatter.format('resourceToLabel(situation-test:nodea, responseTime[127.0.0.1])', metadata);
+            expect(res).to.equal('127.0.0.1');
+        });
+        it('resourceToLabel(invalid)', () => {
+            const res = FunctionFormatter.format('resourceToLabel(foo)', metadata);
+            expect(res).to.equal('foo');
+        });
+        it('resourceToLabel(invalid, invalid)', () => {
+            const res = FunctionFormatter.format('resourceToLabel(foo, bar)', metadata);
+            expect(res).to.equal('foo.bar');
+        });
+
+        it('resourceToName(resourceId)', () => {
+            const res = FunctionFormatter.format('resourceToName(node[situation-test:nodea].responseTime[127.0.0.1])', metadata);
+            expect(res).to.equal('localhost');
+        });
+        it('resourceToName(situation-test:nodea, responseTime[127.0.0.1])', () => {
+            const res = FunctionFormatter.format('resourceToName(situation-test:nodea, responseTime[127.0.0.1])', metadata);
+            expect(res).to.equal('localhost');
+        });
+        it('resourceToName(invalid)', () => {
+            const res = FunctionFormatter.format('resourceToName(foo)', metadata);
+            expect(res).to.equal('foo');
+        });
+        it('resourceToName(invalid, invalid)', () => {
+            const res = FunctionFormatter.format('resourceToName(foo, bar)', metadata);
+            expect(res).to.equal('foo.bar');
+        });
+
+        it('resourceToInterface(resourceId)', () => {
+            const res = FunctionFormatter.format('resourceToInterface(node[situation-test:nodeb].interfaceSnmp[en0-000123456789])', metadata);
+            expect(res).to.equal('en0');
+        });
+        it('resourceToInterface(situation-test:nodeb, interfaceSnmp[en0-000123456789])', () => {
+            const res = FunctionFormatter.format('resourceToInterface(situation-test:nodeb, interfaceSnmp[en0-000123456789])', metadata);
+            expect(res).to.equal('en0');
+        });
+        it('resourceToInterface(invalid)', () => {
+            const res = FunctionFormatter.format('resourceToInterface(foo)', metadata);
+            expect(res).to.equal('foo');
+        });
+        it('resourceToInterface(invalid, invalid)', () => {
+            const res = FunctionFormatter.format('resourceToInterface(foo, bar)', metadata);
+            expect(res).to.equal('foo.bar');
+        });
+    });
+});


### PR DESCRIPTION
This PR adds support for formatting labels based on metadata returned by Meridian 24 and later. (The backend changes are in [this pull request](https://github.com/OpenNMS/opennms/pull/2318).)

It adds support for the following "functions" to be used in the label field:

* `nodeToLabel(<nodeId|foreign-source:foreign-id>)`: the associated node's label
* `resourceToLabel(<nodeCriteria|resourceId>[, partialResourceId])`: the resource's label
* `resourceToName(<nodeCriteria|resourceId>[, partialResourceId])`: the resource's name
* `resourceToInterface(<nodeCriteria|resourceId>[, partialResourceId])`: the interface name

The resource functions can accept either a single argument containing a complete resource ID (`node[situation-test:nodeb].interfaceSnmp[en0-000123456789]`), or two arguments of a node criteria and partial resource ID (`foo:bar, interfaceSnmp[en0-000123456789]` or `1, interfaceSnmp[en0-000123456789]`).