### PR TITLE
HELM-129: Use the Measurements API in relaxed mode

### DIFF
--- a/src/spec/perf_ds_datasource_spec.js
+++ b/src/spec/perf_ds_datasource_spec.js
@@ -55,6 +55,48 @@ describe('OpenNMSPMDatasource', function () {
     });
   });
 
+  describe('relaxed mode', function () {
+    let query = {
+      range: {from: 'now-1h', to: 'now'},
+      targets: [{
+        type: "attribute",
+        nodeId: '1',
+        resourceId: 'nodeSnmp[]',
+        attribute: 'does-not-exist',
+        aggregation: 'AVERAGE'
+      }],
+      interval: '1s'
+    };
+
+    let response = {
+      "step": 300000,
+      "start": 1424211730000,
+      "end": 1424226130000,
+      "timestamps": [1424211730001],
+      "labels": ["loadavg1"],
+      "columns": [
+        {
+          "values": [NaN]
+        }
+      ]
+    };
+
+    it('should filter series that contain only NaNs', function (done) {
+      ctx.backendSrv.datasourceRequest = function (request) {
+        return ctx.$q.when({
+          _request: request,
+          status: 200,
+          data: response
+        });
+      };
+
+      ctx.ds.query(query).then(function (result) {
+        expect(result.data).to.have.length(0);
+        done();
+      });
+    });
+  });
+
   describe('testing for connectivity', function () {
     it('should make a request to /rest/info', function (done) {
       ctx.backendSrv.datasourceRequest = function (request) {


### PR DESCRIPTION
JIRA: https://issues.opennms.org/browse/HELM-129

Here we set `relaxed=true` by default in the queries to the Measurements API. This allows queries to be processes that contain series which are not present.

I opted to always keep this enabled as opposed to adding another flag to enable/disable it.

