### PR TITLE
HELM-134: Define 'en-short' instead of trying to update it

### DIFF
--- a/src/panels/alarm-table/renderer.js
+++ b/src/panels/alarm-table/renderer.js
@@ -4,7 +4,7 @@ import kbn from 'app/core/utils/kbn';
 
 import {Model} from '../../opennms';
 
-moment.updateLocale('en-short', {
+moment.defineLocale('en-short', {
   parentLocale: 'en',
   relativeTime: {
     future: "+%s",


### PR DESCRIPTION
- JIRA: https://issues.opennms.org/browse/HELM-134

HELM-118 broke Grafana's internal date functionality + dashboard reloading when using custom time ranges combined with a dashboard containing an Alarm Table panel.

By using defineLocale() instead of updateLocale(), custom date ranges in Grafana work fine even when using the Alarm Table.