### PR TITLE
HZN-1492 Tag "root cause" alarm when providing feedback

### DIFF
--- a/package.json
+++ b/package.json
@@ -57,7 +57,8 @@
     "flot": "https://github.com/flot/flot#v0.8.3",
     "ionicons": "2.0.1",
     "lodash": "^4.17.11",
-    "opennms": "1.3.1",
+    "ng-tags-input": "^3.2.0",
+    "opennms": "https://github.com/OpenNMS/opennms-js.git#552c4a0d2f89edacd85f2ab7ffe1a7ac3833c5b7",
     "parenthesis": "^3.1.5",
     "q": "^1.5.0"
   },

--- a/package.json
+++ b/package.json
@@ -57,7 +57,6 @@
     "flot": "https://github.com/flot/flot#v0.8.3",
     "ionicons": "2.0.1",
     "lodash": "^4.17.11",
-    "ng-tags-input": "^3.2.0",
     "opennms": "https://github.com/OpenNMS/opennms-js.git#552c4a0d2f89edacd85f2ab7ffe1a7ac3833c5b7",
     "parenthesis": "^3.1.5",
     "q": "^1.5.0"

--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
     "flot": "https://github.com/flot/flot#v0.8.3",
     "ionicons": "2.0.1",
     "lodash": "^4.17.11",
-    "opennms": "https://github.com/OpenNMS/opennms-js.git#552c4a0d2f89edacd85f2ab7ffe1a7ac3833c5b7",
+    "opennms": "1.4.0",
     "parenthesis": "^3.1.5",
     "q": "^1.5.0"
   },

--- a/src/panels/alarm-table/alarm_details.html
+++ b/src/panels/alarm-table/alarm_details.html
@@ -162,7 +162,7 @@
             <div ng-if="editFeedback">
                 <div class="gf-from-group">
                     <bootstrap-tagsinput  ng-model="ctrl.$scope.feedbackTags" data-role="tagsinput" name="tags-input"
-                        tagClass="gf-form-input ng-pristine ng-valid ng-empty ng-touched alarm-details-table feedback-tag-element"
+                        tagClass="feedback-tag-element"
                         class="gf-form-input ng-pristine ng-valid ng-empty ng-touched feedback-tag-input" 
                         focusClass="feedback-tag-element"
                         placeholder="Tags...">

--- a/src/panels/alarm-table/alarm_details.html
+++ b/src/panels/alarm-table/alarm_details.html
@@ -172,8 +172,9 @@
 
                 <div class="gf-from-group">
                     <div class="gf-form">
-                        <input class="gf-form-input ng-pristine ng-valid ng-empty ng-touched" type="text" ng-model="feedbackForm.reason" placeholder="Enter an optional comment">
-                        <button class="btn btn-success" style="margin-left: 1em" ng-click="ctrl.submitEditedFeedback(feedbackForm)">Save</button>
+                        <input class="gf-form-input ng-pristine ng-valid ng-empty ng-touched" type="text" ng-model="ctrl.$scope.feedbackReason" placeholder="Enter an optional comment">
+                        </input>
+                        <button class="btn btn-success" style="margin-left: 1em" ng-click="ctrl.submitEditedFeedback()">Save</button>
                         <button class="btn btn-inverse" ng-click="ctrl.cancelEditedFeedback()">Cancel</button>
                     </div>
                 </div>

--- a/src/panels/alarm-table/alarm_details.html
+++ b/src/panels/alarm-table/alarm_details.html
@@ -125,17 +125,19 @@
                         </td>
                         <td severity>{{summary.label}}</td>
                         <td severity ng-bind-html="summary.logMessage"></td>
-                        <td ng-if="editFeedback" ng-class="feedback-button-td" width="60px">
+                        <td ng-if="editFeedback" class="feedback-button-td" width="60px">
+                            <div style="height=1005;width=100%">
                             <button type="button" class="{{ctrl.detailFeedbackOkayButton(summary.reductionKey)}}"
-                                ng-click="ctrl.markCorrect(summary.reductionKey)">Related</button>
-                        </td>
-                        <td ng-if="editFeedback" ng-class="feedback-button-td" width="60px">
-                            <div style="width: 100%; height: 100%;">
-                                <button type="button" class="{{ctrl.detailFeedbackIncorrectButton(summary.reductionKey)}}"
-                                ng-click="ctrl.markIncorrect(summary.reductionKey)">Not related</button>
+                                ng-click="ctrl.markCorrect(summary.reductionKey)">Is Related</button>
                             </div>
                         </td>
-                        <td ng-if="editFeedback" ng-class="feedback-button-td" width="60px">
+                        <td ng-if="editFeedback" class="feedback-button-td" width="60px">
+                            <div class="feedback-button-div">
+                                <button type="button" class="{{ctrl.detailFeedbackIncorrectButton(summary.reductionKey)}}"
+                                ng-click="ctrl.markIncorrect(summary.reductionKey)">Not Related</button>
+                            </div>
+                        </td>
+                        <td ng-if="editFeedback" class="feedback-button-td" width="60px">
                             <div style="width: 100%; height: 100%;">
                                 <button type="button" class="{{ctrl.detailFeedbackRootCauseButton(summary.reductionKey)}}"
                                 ng-click="ctrl.markRootCause(summary.reductionKey, ctrl.isRootCause(summary.reductionKey))">Root Cause</button>
@@ -143,11 +145,12 @@
                        </td>
                     </tr>
                 </tbody>
-                <tbody ng-repeat-end class="feedback-table">
+                <tbody>
                     <tr ng-if="editFeedback">
-                        <td colspan="3" class="text-right feedback-button">Tally</td>
-                        <td class="text-center feedback-button">{{feedbackCorrectCount}}</td>
-                        <td class="text-center feedback-button">{{feedbackIncorrectCount}}</td>
+                        <td colspan="3" class="text-right feedback-button-td">Tally</td>
+                        <td class="text-center feedback-button-td">{{feedbackCorrectCount}}</td>
+                        <td class="text-center feedback-button-td">{{feedbackIncorrectCount}}</td>
+                        <td class="text-center feedback-button-td">&nbsp;</td>
                     </tr>
                 </tbody>
             </table>
@@ -157,23 +160,32 @@
             </div>
 
             <div ng-if="editFeedback">
+
                 <div class="gf-from-group">
-                    <div class="gf-form">
-                        <button class="btn btn-secondary gf-form-btn" ng-click="{{ctrl.addAlarmQuery()}}" ng-hide="ctrl.datasourceInstance.meta.mixed">
-                            Add Alarm
-                        </button>
-                    </div>
+                    feedback-taglifys---
+                    <feeedbackTags name="feedbackTags" class="gf-form-input ng-pristine ng-valid ng-empty ng-touched"
+                        [settings]="{
+                        whitelist : ['apple', 'babnana', 'crayon'],
+                        blacklist : ['fuck', 'shit']
+                      }"
+                            (add)="ctrl.onTagifyAdd($event)"
+                            (remove)="ctrl.onRemove($event)">
+                            banana
+                    </feeedbackTags>
+                    ---feedback-taglifys
+                    <p/>
+                    feedback-ngTagsInput ---
+                    <tags-input ng-model="ctrl.feedback_tags" 
+                        class="gf-form-input ng-pristine ng-valid ng-empty ng-touched" placeholder="Enter input-tags">
+                        <auto-complete source="ctrl.loadTags($query)"></auto-complete>
+                        blarrch
+                    </tags-input>
+                    --- feedback-ngTagsInput
                 </div>
                 <div class="gf-from-group">
-                    testing tagify wrapper
-                    <tagify [settings]="settings"
-                            (add)="onAdd($event)"
-                            (remove)="onRemove($event)">
-                    </tagify>
-                </div>
-                <div class="gf-from-group">
                     <div class="gf-form">
-                        <input class="gf-form-input ng-pristine ng-valid ng-empty ng-touched" type="text" ng-model="feedbackForm.tags" value="{{ctrl.getFeedbackTags()}}" placeholder="Add tags...">
+                        <input class="gf-form-input ng-pristine ng-valid ng-empty ng-touched" 
+                            type="text" ng-model="feedbackForm.tags" value="{{ctrl.getFeedbackTags()}}" placeholder="Add space separated tags...">
                     </div>
                 </div>
                 <div class="gf-from-group">

--- a/src/panels/alarm-table/alarm_details.html
+++ b/src/panels/alarm-table/alarm_details.html
@@ -108,7 +108,7 @@
                 <thead class="alarm-details-header">
                     <th colspan="2">Label</th>
                     <th>Log Message</th>
-                    <th ng-if="editFeedback" colspan="2" class="text-center">Correlation Feedback</th>
+                    <th ng-if="editFeedback" colspan="3" class="text-center">Correlation Feedback</th>
                 </thead>
                 <tbody ng-repeat-start="node in relatedAlarms">
                     <tr class="alarm-details-node-spacer"><td colspan="{{editFeedback? 5 : 3 }}"><!-- {{node.label + ' / ' + node.$index}} --></td></tr>
@@ -125,17 +125,27 @@
                         </td>
                         <td severity>{{summary.label}}</td>
                         <td severity ng-bind-html="summary.logMessage"></td>
-                        <td ng-if="editFeedback" class="feedback-button" ng-click="ctrl.markCorrect(summary.reductionKey)">
-                            <img ng-src="{{ctrl.detailFeedbackOkayButton(summary.reductionKey)}}" alt="Correct" height="22" width="22" />
+                        <td ng-if="editFeedback" ng-class="feedback-button-td" width="60px">
+                            <button type="button" class="{{ctrl.detailFeedbackOkayButton(summary.reductionKey)}}"
+                                ng-click="ctrl.markCorrect(summary.reductionKey)">Related</button>
                         </td>
-                        <td ng-if="editFeedback" class="feedback-button" ng-click="ctrl.markIncorrect(summary.reductionKey)">
-                            <img ng-src="{{ctrl.detailFeedbackIncorrectButton(summary.reductionKey)}}" alt="Incorrect" height="22" width="22" />
+                        <td ng-if="editFeedback" ng-class="feedback-button-td" width="60px">
+                            <div style="width: 100%; height: 100%;">
+                                <button type="button" class="{{ctrl.detailFeedbackIncorrectButton(summary.reductionKey)}}"
+                                ng-click="ctrl.markIncorrect(summary.reductionKey)">Not related</button>
+                            </div>
                         </td>
+                        <td ng-if="editFeedback" ng-class="feedback-button-td" width="60px">
+                            <div style="width: 100%; height: 100%;">
+                                <button type="button" class="{{ctrl.detailFeedbackRootCauseButton(summary.reductionKey)}}"
+                                ng-click="ctrl.markRootCause(summary.reductionKey, ctrl.isRootCause(summary.reductionKey))">Root Cause</button>
+                            </div>
+                       </td>
                     </tr>
                 </tbody>
-                <tbody class="severity">
+                <tbody ng-repeat-end class="feedback-table">
                     <tr ng-if="editFeedback">
-                        <td colspan="3" class="text-right">Tally</td>
+                        <td colspan="3" class="text-right feedback-button">Tally</td>
                         <td class="text-center feedback-button">{{feedbackCorrectCount}}</td>
                         <td class="text-center feedback-button">{{feedbackIncorrectCount}}</td>
                     </tr>
@@ -145,7 +155,27 @@
             <div ng-if="submittedFeedback">
                 Feedback Submitted.
             </div>
+
             <div ng-if="editFeedback">
+                <div class="gf-from-group">
+                    <div class="gf-form">
+                        <button class="btn btn-secondary gf-form-btn" ng-click="{{ctrl.addAlarmQuery()}}" ng-hide="ctrl.datasourceInstance.meta.mixed">
+                            Add Alarm
+                        </button>
+                    </div>
+                </div>
+                <div class="gf-from-group">
+                    testing tagify wrapper
+                    <tagify [settings]="settings"
+                            (add)="onAdd($event)"
+                            (remove)="onRemove($event)">
+                    </tagify>
+                </div>
+                <div class="gf-from-group">
+                    <div class="gf-form">
+                        <input class="gf-form-input ng-pristine ng-valid ng-empty ng-touched" type="text" ng-model="feedbackForm.tags" value="{{ctrl.getFeedbackTags()}}" placeholder="Add tags...">
+                    </div>
+                </div>
                 <div class="gf-from-group">
                     <div class="gf-form">
                         <input class="gf-form-input ng-pristine ng-valid ng-empty ng-touched" type="text" ng-model="feedbackForm.reason" placeholder="Enter an optional comment">
@@ -158,7 +188,8 @@
                     <a class="btn btn-secondary" ng-click="ctrl.editSituationFeedback()"><i class="fa fa-bars"></i> Re-submit Feedback...</a>
             </div>
             <div ng-if="situationFeebackEnabled && !editFeedback && !hasSituationFeedback" class="text-right">
-                    <a class="btn btn-secondary" ng-click="ctrl.editSituationFeedback()"><i class="fa fa-bars"></i> Submit Feedback...</a>
+                    <a class="btn btn-secondary" ng-click="ctrl.editSituationFeedback()"><i class="fa fa-bars"></i> Provide Feedback...</a>
             </div>
     </div>
 </div>
+

--- a/src/panels/alarm-table/alarm_details.html
+++ b/src/panels/alarm-table/alarm_details.html
@@ -159,7 +159,7 @@
                 Feedback Submitted.
             </div>
 
-            <div ng-if="editFeedback">
+            <div ng-show="editFeedback">
                 <div class="gf-from-group">
                     <bootstrap-tagsinput  ng-model="ctrl.$scope.feedbackTags" data-role="tagsinput" name="tags-input"
                         tagClass="feedback-tag-element"

--- a/src/panels/alarm-table/alarm_details.html
+++ b/src/panels/alarm-table/alarm_details.html
@@ -123,8 +123,8 @@
                                 <i class="fa fa-external-link"></i>
                             </a>
                         </td>
-                        <td severity>{{summary.label}}</td>
-                        <td severity ng-bind-html="summary.logMessage"></td>
+                        <td severity><div class=alarm-detail-logmessage>{{summary.label}}</div></td>
+                        <td severity><div class=alarm-detail-logmessage>{{summary.logMessage}}</div></td>
                         <td ng-if="editFeedback" class="feedback-button-td" width="60px">
                             <div class="feedback-button-div">
                                 <button type="button" class="{{ctrl.detailFeedbackOkayButton(summary.reductionKey)}}"

--- a/src/panels/alarm-table/alarm_details.html
+++ b/src/panels/alarm-table/alarm_details.html
@@ -126,8 +126,8 @@
                         <td severity>{{summary.label}}</td>
                         <td severity ng-bind-html="summary.logMessage"></td>
                         <td ng-if="editFeedback" class="feedback-button-td" width="60px">
-                            <div style="height=1005;width=100%">
-                            <button type="button" class="{{ctrl.detailFeedbackOkayButton(summary.reductionKey)}}"
+                            <div class="feedback-button-div">
+                                <button type="button" class="{{ctrl.detailFeedbackOkayButton(summary.reductionKey)}}"
                                 ng-click="ctrl.markCorrect(summary.reductionKey)">Is Related</button>
                             </div>
                         </td>
@@ -138,7 +138,7 @@
                             </div>
                         </td>
                         <td ng-if="editFeedback" class="feedback-button-td" width="60px">
-                            <div style="width: 100%; height: 100%;">
+                            <div class="feedback-button-div">
                                 <button type="button" class="{{ctrl.detailFeedbackRootCauseButton(summary.reductionKey)}}"
                                 ng-click="ctrl.markRootCause(summary.reductionKey, ctrl.isRootCause(summary.reductionKey))">Root Cause</button>
                             </div>
@@ -160,34 +160,13 @@
             </div>
 
             <div ng-if="editFeedback">
+                <div class="gf-from-group">
+                    <bootstrap-tagsinput  ng-model="ctrl.$scope.feedbackTags"
+                        tagClass="gf-form-input ng-pristine ng-valid ng-empty ng-touched"
+                        class="gf-form-input ng-pristine ng-valid ng-empty ng-touched" placeholder="Tags...">
+                    </bootstrap-tagsinput>
+                </div>
 
-                <div class="gf-from-group">
-                    feedback-taglifys---
-                    <feeedbackTags name="feedbackTags" class="gf-form-input ng-pristine ng-valid ng-empty ng-touched"
-                        [settings]="{
-                        whitelist : ['apple', 'babnana', 'crayon'],
-                        blacklist : ['fuck', 'shit']
-                      }"
-                            (add)="ctrl.onTagifyAdd($event)"
-                            (remove)="ctrl.onRemove($event)">
-                            banana
-                    </feeedbackTags>
-                    ---feedback-taglifys
-                    <p/>
-                    feedback-ngTagsInput ---
-                    <tags-input ng-model="ctrl.feedback_tags" 
-                        class="gf-form-input ng-pristine ng-valid ng-empty ng-touched" placeholder="Enter input-tags">
-                        <auto-complete source="ctrl.loadTags($query)"></auto-complete>
-                        blarrch
-                    </tags-input>
-                    --- feedback-ngTagsInput
-                </div>
-                <div class="gf-from-group">
-                    <div class="gf-form">
-                        <input class="gf-form-input ng-pristine ng-valid ng-empty ng-touched" 
-                            type="text" ng-model="feedbackForm.tags" value="{{ctrl.getFeedbackTags()}}" placeholder="Add space separated tags...">
-                    </div>
-                </div>
                 <div class="gf-from-group">
                     <div class="gf-form">
                         <input class="gf-form-input ng-pristine ng-valid ng-empty ng-touched" type="text" ng-model="feedbackForm.reason" placeholder="Enter an optional comment">
@@ -196,6 +175,7 @@
                     </div>
                 </div>
             </div>
+
             <div ng-if="situationFeebackEnabled && !editFeedback && hasSituationFeedback" class="text-right">
                     <a class="btn btn-secondary" ng-click="ctrl.editSituationFeedback()"><i class="fa fa-bars"></i> Re-submit Feedback...</a>
             </div>

--- a/src/panels/alarm-table/alarm_details.html
+++ b/src/panels/alarm-table/alarm_details.html
@@ -161,9 +161,12 @@
 
             <div ng-if="editFeedback">
                 <div class="gf-from-group">
-                    <bootstrap-tagsinput  ng-model="ctrl.$scope.feedbackTags" name="tags-input"
-                        tagClass="gf-form-input ng-pristine ng-valid ng-empty ng-touched feedback-tag-input"
-                        class="gf-form-input ng-pristine ng-valid ng-empty ng-touched feedback-tag-input" placeholder="Tags...">
+                    <bootstrap-tagsinput  ng-model="ctrl.$scope.feedbackTags" data-role="tagsinput" name="tags-input"
+                        tagClass="gf-form-input ng-pristine ng-valid ng-empty ng-touched alarm-details-table feedback-tag-element"
+                        class="gf-form-input ng-pristine ng-valid ng-empty ng-touched feedback-tag-input" 
+                        focusClass="feedback-tag-element"
+                        placeholder="Tags...">
+                        <typeahead source="ctrl.tagsTypeAhead()" />
                     </bootstrap-tagsinput>
                 </div>
 

--- a/src/panels/alarm-table/alarm_details.html
+++ b/src/panels/alarm-table/alarm_details.html
@@ -124,7 +124,7 @@
                             </a>
                         </td>
                         <td severity><div class=alarm-detail-logmessage>{{summary.label}}</div></td>
-                        <td severity><div class=alarm-detail-logmessage>{{summary.logMessage}}</div></td>
+                        <td severity title="{{summary.logMessage}}"><div class=alarm-detail-logmessage>{{summary.logMessage}}</div></td>
                         <td ng-if="editFeedback" class="feedback-button-td" width="60px">
                             <div class="feedback-button-div">
                                 <button type="button" class="{{ctrl.detailFeedbackOkayButton(summary.reductionKey)}}"

--- a/src/panels/alarm-table/alarm_details.html
+++ b/src/panels/alarm-table/alarm_details.html
@@ -161,9 +161,9 @@
 
             <div ng-if="editFeedback">
                 <div class="gf-from-group">
-                    <bootstrap-tagsinput  ng-model="ctrl.$scope.feedbackTags"
-                        tagClass="gf-form-input ng-pristine ng-valid ng-empty ng-touched"
-                        class="gf-form-input ng-pristine ng-valid ng-empty ng-touched" placeholder="Tags...">
+                    <bootstrap-tagsinput  ng-model="ctrl.$scope.feedbackTags" name="tags-input"
+                        tagClass="gf-form-input ng-pristine ng-valid ng-empty ng-touched feedback-tag-input"
+                        class="gf-form-input ng-pristine ng-valid ng-empty ng-touched feedback-tag-input" placeholder="Tags...">
                     </bootstrap-tagsinput>
                 </div>
 

--- a/src/panels/alarm-table/alarm_details.js
+++ b/src/panels/alarm-table/alarm_details.js
@@ -67,7 +67,7 @@ export class AlarmDetailsCtrl {
     }
 
     // Feedback Tags
-    $scope.existingFeedbackTags = new Set([]);
+    $scope.feedbackTags = new Set([]);
 
     // If this is a Situation, collect any correlation feedback previously submitted
     if ($scope.alarm.relatedAlarms && $scope.alarm.relatedAlarms.length > 0) {
@@ -202,9 +202,9 @@ export class AlarmDetailsCtrl {
 
   submitEditedFeedback(form) {
     for (let feedback of this.$scope.situationFeedback) {
+      feedback.tags = this.$scope.feedbackTags;
       if (form) {
         feedback.reason = form.reason;
-        feedback.tags = this.$scope.feedbackTags;
       }
     }
     this.submitFeedback(this.$scope.situationFeedback);
@@ -228,14 +228,14 @@ export class AlarmDetailsCtrl {
 
   updateFeedback(feedback) {
     for (let fb of feedback) {
-      for (let ifb of this.$scope.situationFeedback) {
-        if (fb.alarmKey === ifb.alarmKey)
-          ifb = fb;
-      }
+      const index = this.$scope.situationFeedback.findIndex(ifb => ifb.alarmKey === fb.alarmKey);
+      this.$scope.situationFeedback[index].rootCause = fb.rootCause;
+      this.$scope.situationFeedback[index].tags = fb.tags;
       for (let tag of fb.tags) {
-        this.$scope.existingFeedbackTags.add(tag);
+        this.$scope.feedbackTags.add(tag);
       }
     }
+    $('tags-input').tagsinput('refresh');
   }
 
   editSituationFeedback() {

--- a/src/panels/alarm-table/alarm_details.js
+++ b/src/panels/alarm-table/alarm_details.js
@@ -1,6 +1,7 @@
 import { TableRenderer } from "./renderer"
 import md5 from 'crypto-js/md5';
 import {Model} from 'opennms';
+import _ from 'lodash';
 
 const compareStrings = (a, b) => {
   return (a || b) ? (!a ? -1 : !b ? 1 : a.localeCompare(b)) : 0;
@@ -169,11 +170,13 @@ export class AlarmDetailsCtrl {
 
   markIncorrect(reductionKey) {
     for (let feedback of this.$scope.situationFeedback) {
-      if (feedback.alarmKey === reductionKey && feedback.feedbackType === Model.FeedbackTypes.CORRECT) {
-        feedback.feedbackType = Model.FeedbackTypes.FALSE_POSITIVE;
-        this.$scope.feedbackCorrectCount--;
-        this.$scope.feedbackIncorrectCount++;
-        break;
+      if (feedback.alarmKey === reductionKey) {
+        if (feedback.feedbackType == Model.FeedbackTypes.CORRECT) {
+          feedback.feedbackType = Model.FeedbackTypes.FALSE_POSITIVE;
+          this.$scope.feedbackCorrectCount--;
+          this.$scope.feedbackIncorrectCount++;
+          break;
+        }
       }
     }
   }
@@ -233,9 +236,11 @@ export class AlarmDetailsCtrl {
       this.$scope.situationFeedback[index].tags = fb.tags;
       for (let tag of fb.tags) {
         this.$scope.feedbackTags.add(tag);
+        $('#tags-input').tagsinput('add', tag);
       }
     }
-    $('tags-input').tagsinput('refresh');
+    this.$scope.retrievedFeedback = _.clone(this.$scope.situationFeedback);
+    $('#tags-input').tagsinput('refresh');
   }
 
   editSituationFeedback() {
@@ -258,7 +263,7 @@ export class AlarmDetailsCtrl {
   }
 
   cancelEditedFeedback() {
-    this.$scope.situationFeedback = this.initalizeFeeback();
+    this.$scope.situationFeedback = _.clone(this.$scope.retrievedFeedback);
     this.$scope.editFeedback = false;
     this.$scope.submittedFeedback = false;
   }
@@ -275,6 +280,12 @@ export class AlarmDetailsCtrl {
         return ds;
       }
     });
+  }
+
+  tagsTypeAhead(query) {
+    // TODO - query rest endpoint for tags on the first time and then further filter them as typing continues
+    // or hit rest endpoint each time...
+    console.log("TYPEAHEAD: " + query);
   }
 
   showSelectionModal(label, columns, search, callback) {

--- a/src/panels/alarm-table/alarm_details.js
+++ b/src/panels/alarm-table/alarm_details.js
@@ -59,6 +59,7 @@ export class AlarmDetailsCtrl {
     // Situation Feedback
     $scope.situationFeebackEnabled = false;
     $scope.feebackButton = this.CORRECT_OUTLINED;
+    $scope.tagsInput = $('#tags-input');
 
     // Compute the tabs
     $scope.tabs = ['Overview', 'Memos'];
@@ -166,6 +167,7 @@ export class AlarmDetailsCtrl {
       alarmFeedback.reason = "ALL_CORRECT";
       alarmFeedback.rootCause = false;
       alarmFeedback.tags = [];
+      alarmFeedback.timestamp = 0;
       alarmFeedback.user = this.contextSrv.user.login;
       feedback.push(alarmFeedback);
       this.$scope.feedbackCorrectCount++;
@@ -261,17 +263,23 @@ export class AlarmDetailsCtrl {
   }
 
   updateFeedback(feedback) {
-    for (let fb of feedback) {
+    // We get all feedback from the datasource.
+    // Use only the latest that matches the current relatedAlarms.
+    let sortedFeedback = _.orderBy(feedback, ['timestamp'],  ['desc']);
+    for (let fb of sortedFeedback) {
       const index = this.$scope.situationFeedback.findIndex(ifb => ifb.alarmKey === fb.alarmKey);
-      this.$scope.situationFeedback[index].rootCause = fb.rootCause;
-      this.$scope.situationFeedback[index].tags = fb.tags;
-      this.$scope.situationFeedback[index].feedbackType = fb.feedbackType;
-      for (let tag of fb.tags) {
-        this.$scope.feedbackTags.add(tag);
-        $('#tags-input').tagsinput('add', tag);
+      if (this.$scope.situationFeedback[index].timestamp < fb.timestamp) {
+        this.$scope.situationFeedback[index].rootCause = fb.rootCause;
+        this.$scope.situationFeedback[index].tags = fb.tags;
+        this.$scope.situationFeedback[index].feedbackType = fb.feedbackType;
+        this.$scope.situationFeedback[index].timestamp = fb.timestamp;
+        for (let tag of fb.tags) {
+          this.$scope.feedbackTags.add(tag);
+          this.$scope.tagsInput.tagsinput('add', tag);
+        }
       }
     }
-    $('#tags-input').tagsinput('refresh');
+    this.resetCounters();
   }
 
   editSituationFeedback() {

--- a/src/panels/alarm-table/alarm_details.js
+++ b/src/panels/alarm-table/alarm_details.js
@@ -124,7 +124,7 @@ export class AlarmDetailsCtrl {
     let button = this.INCORRECT_OUTLINED;
     if (this.$scope.situationFeedback) {
       for (let feedback of this.$scope.situationFeedback) {
-        if (feedback.alarmKey === reductionKey && feedback.feedbackType === Model.FeedbackTypes.FALSE_POSITIVE) {
+        if (feedback.alarmKey === reductionKey && feedback.feedbackType.id === Model.FeedbackTypes.FALSE_POSITIVE.id) {
           button = this.INCORRECT_FILLED;
           break;
         }
@@ -137,7 +137,7 @@ export class AlarmDetailsCtrl {
     let button = this.CORRECT_FILLED;
     if (this.$scope.situationFeedback) {
       for (let feedback of this.$scope.situationFeedback) {
-        if (feedback.alarmKey === reductionKey && feedback.feedbackType === Model.FeedbackTypes.FALSE_POSITIVE) {
+        if (feedback.alarmKey === reductionKey && feedback.feedbackType.id === Model.FeedbackTypes.FALSE_POSITIVE.id) {
           button = this.CORRECT_OUTLINED;
           break;
         }
@@ -204,7 +204,7 @@ export class AlarmDetailsCtrl {
 
   markCorrect(reductionKey) {
     for (let feedback of this.$scope.situationFeedback) {
-      if (feedback.alarmKey === reductionKey && feedback.feedbackType === Model.FeedbackTypes.FALSE_POSITIVE) {
+      if (feedback.alarmKey === reductionKey && feedback.feedbackType.id === Model.FeedbackTypes.FALSE_POSITIVE.id) {
         feedback.feedbackType = Model.FeedbackTypes.CORRECT;
         this.$scope.feedbackCorrectCount++;
         this.$scope.feedbackIncorrectCount--;
@@ -229,7 +229,7 @@ export class AlarmDetailsCtrl {
     this.$scope.feedbackCorrectCount = this.$scope.situationFeedback.length;
     this.$scope.feedbackIncorrectCount = 0;
     for(let fb of this.$scope.situationFeedback) {
-      if (fb.feedbackType === Model.FeedbackTypes.FALSE_POSITIVE) {
+      if (fb.feedbackType.id === Model.FeedbackTypes.FALSE_POSITIVE.id) {
         this.$scope.feedbackCorrectCount--;
         this.$scope.feedbackIncorrectCount++;
       }
@@ -237,8 +237,10 @@ export class AlarmDetailsCtrl {
   }
 
   submitEditedFeedback(form) {
+    const now = Date.now();
     for (let feedback of this.$scope.situationFeedback) {
       feedback.tags = this.$scope.feedbackTags;
+      feedback.timestamp = now;
       if (form) {
         feedback.reason = form.reason;
       }

--- a/src/panels/alarm-table/alarm_details.js
+++ b/src/panels/alarm-table/alarm_details.js
@@ -320,50 +320,6 @@ export class AlarmDetailsCtrl {
     console.log("TYPEAHEAD: " + query);
   }
 
-  showSelectionModal(label, columns, search, callback) {
-    // var scope = this.$scope.$new();
-
-    // scope.label = label;
-    // scope.columns = columns;
-    // scope.search = search;
-
-    // scope.result = this.$q.defer();
-    // scope.result.promise.then(callback);
-
-    // var modal = this.$modal({
-    //   template: 'public/plugins/opennms-helm-app/datasources/perf-ds/partials/modal.selection.html',
-    //   persist: false,
-    //   show: false,
-    //   scope: scope,
-    //   keyboard: false
-    // });
-    // this.$q.when(modal).then(function (modalEl) { modalEl.modal('show'); });
-  }
-
-  addAlarmQuery() {
-    var self = this;
-    this.showSelectionModal("alarms", {
-      'Node': 'node',
-      'Description': 'description',
-      'Severity': 'dseverity'
-    }, function () {
-      return "";
-      /* self.datasource
-        .getAvailableFilters()
-        .then(function (results) {
-          return {
-            'count': results.data.length,
-            'totalCount': results.data.length,
-            'rows': results.data
-          };
-        });
-        */
-    }, function (filter) {
-      self.target.filter = filter;
-      // self.targetBlur('filter');
-    });
-  }
-
 }
 
 /** @ngInject */

--- a/src/panels/alarm-table/alarm_details.js
+++ b/src/panels/alarm-table/alarm_details.js
@@ -2,7 +2,8 @@ import { TableRenderer } from "./renderer"
 import md5 from 'crypto-js/md5';
 import {Model} from 'opennms';
 
-import Tagify from '@yaireo/tagify';
+import Tagify from '../../yaireo/tagify/tagify';
+// require('../../yaireo/tagify/tagify.service.ts');
 
 const compareStrings = (a, b) => {
   return (a || b) ? (!a ? -1 : !b ? 1 : a.localeCompare(b)) : 0;
@@ -10,6 +11,7 @@ const compareStrings = (a, b) => {
 
 export class AlarmDetailsCtrl {
   /** @ngInject */
+//  constructor($scope, backendSrv, contextSrv, datasourceSrv, tagifyService) {
   constructor($scope, backendSrv, contextSrv, datasourceSrv) {
     this.$scope = $scope;
     this.backendSrv = backendSrv;
@@ -60,6 +62,13 @@ export class AlarmDetailsCtrl {
     // Situation Feedback
     $scope.situationFeebackEnabled = false;
     $scope.feebackButton = this.CORRECT_OUTLINED;
+    $scope.tagArray =  [
+      { text: 'just' },
+      { text: 'some' },
+      { text: 'cool' },
+      { text: 'tags' }
+    ];
+    $scope.feedback_tags = $scope.tagArray;
 
     // Compute the tabs
     $scope.tabs = ['Overview', 'Memos'];
@@ -70,9 +79,15 @@ export class AlarmDetailsCtrl {
 
     // Feedback Tags
     $scope.feedbackTags = new Set([]);
-    $scope.feedbackTagsInput = document.querySelector('input[name=tags]');
+    $scope.feedbackTagsInput = document.querySelector('input[name=feeedbackTags]');
     // init Tagify script on the above inputs
-    $scope.tagify = new Tagify();
+    // $scope.tagify = document.querySelector('input[name=feeedbackTags]'),
+    //   tagified = new Tagify($scope.tagify,
+    //     {
+    //       whitelist : ["A# .NET", "A# (Axiom)", "A-0 System"],
+    //       blacklist : ['fuck', 'shit']
+    //     });
+
 
     // If this is a Situation, collect any correlation feedback previously submitted
     if ($scope.alarm.relatedAlarms && $scope.alarm.relatedAlarms.length > 0) {
@@ -139,7 +154,11 @@ export class AlarmDetailsCtrl {
   }
 
   getFeedbackTags() {
-    return this.$scope.feedbackTags;
+    var tagsStr = '';
+    for (let t of this.$scope.feedbackTags) {
+      tagsStr += t + " ";
+    }
+    return tagsStr;
   }
 
   initalizeFeeback() {
@@ -169,6 +188,11 @@ export class AlarmDetailsCtrl {
       }
     }
     return false;
+  }
+
+  loadtags(prefix) {
+    console.log("Load tags: " + prefix);
+    return this.$scope.tagArray;
   }
 
   markIncorrect(reductionKey) {
@@ -202,9 +226,12 @@ export class AlarmDetailsCtrl {
         feedback.rootCause = false;
       }
     }
-
   }
 
+  onTagifyAdd(event) {
+    //banana
+    console.log(event);
+  }
   submitEditedFeedback(form) {
     for (let feedback of this.$scope.situationFeedback) {
       if (form) {
@@ -241,7 +268,7 @@ export class AlarmDetailsCtrl {
         this.$scope.feedbackTags.add(tag);
       }
     }
-    this.$scope.tagify.addTags(this.$scope.feedbackTags);
+    // this.$scope.tagify.addTags(this.$scope.feedbackTags);
   }
 
   editSituationFeedback() {

--- a/src/panels/alarm-table/alarm_details.js
+++ b/src/panels/alarm-table/alarm_details.js
@@ -192,7 +192,7 @@ export class AlarmDetailsCtrl {
   markIncorrect(reductionKey) {
     for (let feedback of this.$scope.situationFeedback) {
       if (feedback.alarmKey === reductionKey) {
-        if (feedback.feedbackType == Model.FeedbackTypes.CORRECT) {
+        if (feedback.feedbackType.id == Model.FeedbackTypes.CORRECT.id) {
           feedback.feedbackType = Model.FeedbackTypes.FALSE_POSITIVE;
           this.$scope.feedbackCorrectCount--;
           this.$scope.feedbackIncorrectCount++;

--- a/src/panels/alarm-table/alarm_details.js
+++ b/src/panels/alarm-table/alarm_details.js
@@ -2,16 +2,12 @@ import { TableRenderer } from "./renderer"
 import md5 from 'crypto-js/md5';
 import {Model} from 'opennms';
 
-import Tagify from '../../yaireo/tagify/tagify';
-// require('../../yaireo/tagify/tagify.service.ts');
-
 const compareStrings = (a, b) => {
   return (a || b) ? (!a ? -1 : !b ? 1 : a.localeCompare(b)) : 0;
 };
 
 export class AlarmDetailsCtrl {
   /** @ngInject */
-//  constructor($scope, backendSrv, contextSrv, datasourceSrv, tagifyService) {
   constructor($scope, backendSrv, contextSrv, datasourceSrv) {
     this.$scope = $scope;
     this.backendSrv = backendSrv;
@@ -62,13 +58,6 @@ export class AlarmDetailsCtrl {
     // Situation Feedback
     $scope.situationFeebackEnabled = false;
     $scope.feebackButton = this.CORRECT_OUTLINED;
-    $scope.tagArray =  [
-      { text: 'just' },
-      { text: 'some' },
-      { text: 'cool' },
-      { text: 'tags' }
-    ];
-    $scope.feedback_tags = $scope.tagArray;
 
     // Compute the tabs
     $scope.tabs = ['Overview', 'Memos'];
@@ -78,16 +67,7 @@ export class AlarmDetailsCtrl {
     }
 
     // Feedback Tags
-    $scope.feedbackTags = new Set([]);
-    $scope.feedbackTagsInput = document.querySelector('input[name=feeedbackTags]');
-    // init Tagify script on the above inputs
-    // $scope.tagify = document.querySelector('input[name=feeedbackTags]'),
-    //   tagified = new Tagify($scope.tagify,
-    //     {
-    //       whitelist : ["A# .NET", "A# (Axiom)", "A-0 System"],
-    //       blacklist : ['fuck', 'shit']
-    //     });
-
+    $scope.existingFeedbackTags = new Set([]);
 
     // If this is a Situation, collect any correlation feedback previously submitted
     if ($scope.alarm.relatedAlarms && $scope.alarm.relatedAlarms.length > 0) {
@@ -151,14 +131,6 @@ export class AlarmDetailsCtrl {
       button = this.ROOT_CAUSE_YES;
     }
     return button;
-  }
-
-  getFeedbackTags() {
-    var tagsStr = '';
-    for (let t of this.$scope.feedbackTags) {
-      tagsStr += t + " ";
-    }
-    return tagsStr;
   }
 
   initalizeFeeback() {
@@ -228,15 +200,11 @@ export class AlarmDetailsCtrl {
     }
   }
 
-  onTagifyAdd(event) {
-    //banana
-    console.log(event);
-  }
   submitEditedFeedback(form) {
     for (let feedback of this.$scope.situationFeedback) {
       if (form) {
         feedback.reason = form.reason;
-        feedback.tags = form.tags.split(" ");
+        feedback.tags = this.$scope.feedbackTags;
       }
     }
     this.submitFeedback(this.$scope.situationFeedback);
@@ -265,10 +233,9 @@ export class AlarmDetailsCtrl {
           ifb = fb;
       }
       for (let tag of fb.tags) {
-        this.$scope.feedbackTags.add(tag);
+        this.$scope.existingFeedbackTags.add(tag);
       }
     }
-    // this.$scope.tagify.addTags(this.$scope.feedbackTags);
   }
 
   editSituationFeedback() {

--- a/src/panels/alarm-table/alarm_details.js
+++ b/src/panels/alarm-table/alarm_details.js
@@ -270,14 +270,16 @@ export class AlarmDetailsCtrl {
     let sortedFeedback = _.orderBy(feedback, ['timestamp'],  ['desc']);
     for (let fb of sortedFeedback) {
       const index = this.$scope.situationFeedback.findIndex(ifb => ifb.alarmKey === fb.alarmKey);
-      if (this.$scope.situationFeedback[index].timestamp < fb.timestamp) {
-        this.$scope.situationFeedback[index].rootCause = fb.rootCause;
-        this.$scope.situationFeedback[index].tags = fb.tags;
-        this.$scope.situationFeedback[index].feedbackType = fb.feedbackType;
-        this.$scope.situationFeedback[index].timestamp = fb.timestamp;
-        for (let tag of fb.tags) {
-          this.$scope.feedbackTags.add(tag);
-          this.$scope.tagsInput.tagsinput('add', tag);
+      if (index >= 0 && index <= this.$scope.situationFeedback.length) {
+        if (this.$scope.situationFeedback[index].timestamp < fb.timestamp) {
+          this.$scope.situationFeedback[index].rootCause = fb.rootCause;
+          this.$scope.situationFeedback[index].tags = fb.tags;
+          this.$scope.situationFeedback[index].feedbackType = fb.feedbackType;
+          this.$scope.situationFeedback[index].timestamp = fb.timestamp;
+          for (let tag of fb.tags) {
+            this.$scope.feedbackTags.add(tag);
+            this.$scope.tagsInput.tagsinput('add', tag);
+          }
         }
       }
     }
@@ -304,7 +306,10 @@ export class AlarmDetailsCtrl {
   }
 
   cancelEditedFeedback() {
-    this.$scope.situationFeedback = this.clone(this.$scope.retrievedFeedback);
+    // if we retrieved feedback from the server, restore that when cancelling.
+    if (this.$scope.retrievedFeedback != undefined) {
+      this.$scope.situationFeedback = this.clone(this.$scope.retrievedFeedback);
+    }
     this.$scope.editFeedback = false;
     this.$scope.submittedFeedback = false;
     this.resetCounters();

--- a/src/panels/alarm-table/alarm_details.js
+++ b/src/panels/alarm-table/alarm_details.js
@@ -280,7 +280,10 @@ export class AlarmDetailsCtrl {
         this.$scope.situationFeedback[index].feedbackType = fb.feedbackType;
         this.$scope.situationFeedback[index].timestamp = fb.timestamp;
         for (let tag of fb.tags) {
-          this.$scope.retrievedTags.push(tag);
+          // don't duplicate tags
+          if (!this.$scope.retrievedTags.includes(tag)) {
+            this.$scope.retrievedTags.push(tag);
+          }
         }
         this.$scope.retrievedReason = fb.reason;
       }

--- a/src/panels/alarm-table/sass/_table.scss
+++ b/src/panels/alarm-table/sass/_table.scss
@@ -371,6 +371,7 @@ $details-header-font-weight: 500;
     widows: 100%;
     height: 100%;
     box-sizing: content-box;
+    border-radius: 0px;
   }
 
   .feedback-button-correct {
@@ -385,10 +386,11 @@ $details-header-font-weight: 500;
     background-color: #9030C0;
   }
 
-  .feedback-tag-input {
-    display: inline !important;
-    padding: 0 0 !important;
-  }
+}
+
+.feedback-tag-input {
+  display: inline !important;
+  padding: 0 0 !important;
 }
 
 .feedback-tag-element {

--- a/src/panels/alarm-table/sass/_table.scss
+++ b/src/panels/alarm-table/sass/_table.scss
@@ -386,7 +386,12 @@ $details-header-font-weight: 500;
   }
 
   .feedback-tag-input {
-    display: inline;
-    padding: 0 0;
+    display: inline !important;
+    padding: 0 0 !important;
+  }
+
+  .feedback-tag-element {
+    background-color: #262628 !important;
+    border-color: antiquewhite !important;
   }
 }

--- a/src/panels/alarm-table/sass/_table.scss
+++ b/src/panels/alarm-table/sass/_table.scss
@@ -269,12 +269,6 @@ $critical-color: #DB4345;
   font-size: .875rem !important;
 }
 
-.feedback-button {
-  text-align: center;
-  // Remove the padding adding by the dense table class. Works well for text, but not for images
-  padding-left: 0em !important;
-}
-
 .picked-up {
   opacity: 0.3;
 }
@@ -389,5 +383,10 @@ $details-header-font-weight: 500;
 
   .feedback-button-root-cause {
     background-color: #9030C0;
+  }
+
+  .feedback-tag-input {
+    display: inline;
+    padding: 0 0;
   }
 }

--- a/src/panels/alarm-table/sass/_table.scss
+++ b/src/panels/alarm-table/sass/_table.scss
@@ -352,7 +352,8 @@ $details-header-font-weight: 500;
   }
   
   .feedback-button-td {
-    padding: 0 0;
+    display: table-cell;
+    padding: 0 0 0 0 !important;
   }
 
   .feedback-button-div {

--- a/src/panels/alarm-table/sass/_table.scss
+++ b/src/panels/alarm-table/sass/_table.scss
@@ -350,8 +350,10 @@ $details-header-font-weight: 500;
   .feedback-table {
     table-layout: fixed;
   }
-  
+
   .feedback-button-td {
+    box-sizing: content-box;
+    vertical-align: baseline;
     display: table-cell;
     padding: 0 0 0 0 !important;
   }
@@ -359,7 +361,10 @@ $details-header-font-weight: 500;
   .feedback-button-div {
     width: 100%;
     height: 100%;
-    padding: 0 0;
+    box-sizing: content-box;
+    padding: 0 0 0 0;
+    padding-bottom: 0;
+    display: inline-block;
   }
 
   .feedback-button {
@@ -368,9 +373,10 @@ $details-header-font-weight: 500;
     display: block;
     font-size: 10px;
     text-align: center;
-    padding: 10px 10px;
+    padding: 10px;
     widows: 100%;
     height: 100%;
+    box-sizing: content-box;
   }
 
   .feedback-button-correct {

--- a/src/panels/alarm-table/sass/_table.scss
+++ b/src/panels/alarm-table/sass/_table.scss
@@ -347,4 +347,40 @@ $details-header-font-weight: 500;
     }
   }
 
+  .feedback-table {
+    table-layout: fixed;
+  }
+  
+  .feedback-button-td {
+    padding: 0 0;
+  }
+
+  .feedback-button-div {
+    width: 100%;
+    height: 100%;
+    padding: 0 0;
+  }
+
+  .feedback-button {
+    background-color: #262628;
+    color: white;
+    display: block;
+    font-size: 10px;
+    text-align: center;
+    padding: 10px 10px;
+    widows: 100%;
+    height: 100%;
+  }
+
+  .feedback-button-correct {
+    background-color: #299c46;
+  }
+
+  .feedback-button-incorrect {
+    background-color: #ca4333;
+  }
+
+  .feedback-button-root-cause {
+    background-color: #9030C0;
+  }
 }

--- a/src/panels/alarm-table/sass/_table.scss
+++ b/src/panels/alarm-table/sass/_table.scss
@@ -389,9 +389,9 @@ $details-header-font-weight: 500;
     display: inline !important;
     padding: 0 0 !important;
   }
+}
 
-  .feedback-tag-element {
-    background-color: #262628 !important;
-    border-color: antiquewhite !important;
-  }
+.feedback-tag-element {
+  background-color: #262628 !important;
+  border-color: antiquewhite !important;
 }

--- a/src/panels/alarm-table/sass/_table.scss
+++ b/src/panels/alarm-table/sass/_table.scss
@@ -388,6 +388,11 @@ $details-header-font-weight: 500;
 
 }
 
+.alarm-detail-logmessage {
+  overflow: hidden;
+  height: 20px;
+}
+
 .feedback-tag-input {
   display: inline !important;
   padding: 0 0 !important;

--- a/yarn.lock
+++ b/yarn.lock
@@ -5148,10 +5148,10 @@ opener@^1.5.1:
   resolved "https://registry.yarnpkg.com/opener/-/opener-1.5.1.tgz#6d2f0e77f1a0af0032aca716c2c1fbb8e7e8abed"
   integrity sha512-goYSy5c2UXE4Ra1xixabeVh1guIX/ZV/YokJksb6q2lubWu6UbvPQ20p542/sFIll1nl8JnCyK9oBaOcCWXwvA==
 
-opennms@1.3.1:
-  version "1.3.1"
-  resolved "https://registry.yarnpkg.com/opennms/-/opennms-1.3.1.tgz#97c6f89d1837e613d00de73c02fd790a2878143a"
-  integrity sha512-LF6Tv1NyzZH94Sw4H4fuuwA+uffLR07Dgc3HqIbS0gOWzQE+P+lYVylhoeymj+FSjb9ywWAXKS2lBfQasFlZTw==
+opennms@1.4.0:
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/opennms/-/opennms-1.4.0.tgz#47a668bd40ec4a3026e7c7a6af746e7990e4ed43"
+  integrity sha512-Bge+Q5/zBPGWBWyl4q3WoRhNwEISbyZImHaSJQA1m7rDcQcGTQ/Cw1e0VVAIugeCKzppeUuDj8hoK7/bKI1VrA==
   dependencies:
     axios "^0.16.1"
     cli-table3 "^0.5.0"


### PR DESCRIPTION
This PR consists of the HELM UI work to allow a user to select ONE of the related alarms as the 'root cause' of the Situation.
This information is passed via opennms-js/ReST to the OpenNMS server and then persisted in ElasticSearch.
Additionally, a user can provide a list of 'Tags' that will be attached to each situation/alarm feedback record.

This PR also offers a different style on the feedback buttons in conjunction with the new RootCause button.

That said, there is probably lots of room for improvement, so all suggestions are welcome.

JIRA: https://issues.opennms.org/browse/HZN-1492

Currently, the UI looks like this:

![image](https://user-images.githubusercontent.com/38085611/55994489-db381b00-5c7f-11e9-855a-31b744f4863f.png)
