### PR TITLE
HELM-147: wrap log/description/operinst

### DIFF
--- a/src/panels/alarm-table/alarm_details.html
+++ b/src/panels/alarm-table/alarm_details.html
@@ -1,4 +1,4 @@
-<div class="modal-body alarm-details" style="overflow: auto;" dynamic-height ng-class="'opennms-theme-' + (ctrl.panel.theme ? ctrl.panel.theme : 'helm')">
+<div class="modal-body alarm-details" ng-class="'opennms-theme-' + (ctrl.panel.theme ? ctrl.panel.theme : 'helm')">
     <div class="modal-header">
         <h2 class="modal-header-title">
             <a href="{{ alarm.detailsPage }}" target="_blank"><i class="fa fa-external-link"></i></a>
@@ -18,28 +18,28 @@
         </a>
     </div>
 
-    <div class="modal-content">
+    <div class="modal-content" dynamic-height>
         <div ng-if="editor.index == 0">
-            <table class="filter-table gf-form-group alarm-details-table">
+            <table class="filter-table gf-form-group alarm-details-table severity">
                 <tr>
                     <td>UEI</td>
-                    <td>{{alarm.uei}}</td>
+                    <td class="wrap">{{alarm.uei}}</td>
                 </tr>
-                <tr>
-                    <td>Severity</td>
-                    <td><i class="icon" ng-class="severityIcon"></i> {{alarm.severity.label}}</td>
+                <tr ng-class="(severity === true || severity === 'row') ? alarm.severity.label.toLowerCase() : ''">
+                    <td >Severity</td>
+                    <td class="wrap severity-icon"><span ng-class="severity === 'column' ? alarm.severity.label.toLowerCase() : ''"><i class="icon" ng-class="severityIcon"></i> {{alarm.severity.label}}</span></td>
                 </tr>
                 <tr>
                     <td>Log Message</td>
-                    <td ng-bind-html="alarm.logMessage"></td>
+                    <td class="wrap log-message" ng-bind-html="alarm.logMessage"></td>
                 </tr>
                 <tr>
                     <td style="vertical-align: text-top">Description</td>
-                    <td style="white-space: normal" ng-bind-html="alarm.description"></td>
+                    <td class="wrap description" style="white-space: normal" ng-bind-html="alarm.description"></td>
                 </tr>
                 <tr ng-if="alarm.operatorInstructions">
                     <td>Operator Instructions</td>
-                    <td ng-bind-html="alarm.operatorInstructions"></td>
+                    <td class="wrap operator-instructions" ng-bind-html="alarm.operatorInstructions"></td>
                 </tr>
             </table>
             <table class="filter-table gf-form-group alarm-details-table">
@@ -57,7 +57,7 @@
                 </tr>
                 <tr>
                     <td>Reduction Key</td>
-                    <td>{{alarm.reductionKey}}</td>
+                    <td class="wrap reduction-key">{{alarm.reductionKey}}</td>
                 </tr>
                 <tr ng-if="alarm.managedObjectInstance">
                     <td>Managed Object Instance</td>
@@ -85,9 +85,7 @@
             </div>
         </div>
 
-        <div ng-if="editor.index > 1 && tabs[editor.index] == 'JSON'" style="overflow: auto; overflow-wrap: normal">
-            <pre style="white-space: pre">{{ getAlarmString() }}</pre>
-        </div>
+        <span ng-if="editor.index > 1 && tabs[editor.index] == 'JSON'" style="overflow-wrap: normal; white-space: pre">{{ getAlarmString() }}</span>
 
         <div ng-if="editor.index > 1 && tabs[editor.index] == 'Ticketing'">
             <table class="filter-table gf-form-group">

--- a/src/panels/alarm-table/module.js
+++ b/src/panels/alarm-table/module.js
@@ -637,11 +637,20 @@ export { AlarmTableCtrl, AlarmTableCtrl as PanelCtrl };
 coreModule.directive('alarmDetailsAsModal',  alarmDetailsAsDirective);
 coreModule.directive('memoEditor',  memoEditorAsDirective);
 coreModule.directive('contextMenu', contextMenuAsDirective());
+
 coreModule.directive('dynamicHeight', function($window) {
   // Used to dynamically size the alarm details modal window
   return{
     link: function(scope, element /*, attrs */) {
-      element.css('max-height', $window.innerHeight * 0.8 + 'px');
+      const doResize = () => {
+        element.css('max-height', $window.innerHeight * 0.8 + 'px');
+      };
+
+      doResize();
+      element.on('$destroy', () => {
+        $window.removeEventListener('resize', doResize);
+      });
+      $window.addEventListener('resize', doResize);
     }
   }
 });

--- a/src/panels/alarm-table/sass/_table.scss
+++ b/src/panels/alarm-table/sass/_table.scss
@@ -7,6 +7,8 @@ $ionicons-font-path: '../../../../node_modules/ionicons/fonts';
 $padding-small: 0.25em;
 $padding-large: 0.50em;
 
+$grafana-default-table-line-height: 30px;
+
 .table-panel-container {
   padding-top: 2.45em;
 }
@@ -296,8 +298,14 @@ $severity-font-weight: normal;
 $details-header-font-weight: 500;
 
 .alarm-details {
+  .filter-table {
+    width: auto;
+  }
   .modal-header-title {
     font-weight: $details-header-font-weight;
+  }
+  .modal-content {
+    overflow: auto;
   }
 }
 
@@ -305,6 +313,14 @@ $details-header-font-weight: 500;
   th {
     font-size: 1.125rem;
     font-weight: $details-header-font-weight;
+  }
+  .wrap {
+    white-space: normal;
+    overflow-wrap: break-word;
+  }
+  .severity-icon span {
+    margin-left: -10px;
+    padding: 10px;
   }
 
   tbody {
@@ -325,6 +341,19 @@ $details-header-font-weight: 500;
       border-image-width: 0 !important;
       pointer-events: none;
       height: 1rem;
+    }
+
+    .log-message {
+      max-height: $grafana-default-table-line-height * 2;
+      overflow-y: auto;
+    }
+    .description {
+      max-height: $grafana-default-table-line-height * 5;
+      overflow-y: auto;
+    }
+    .operator-instructions {
+      max-height: $grafana-default-table-line-height * 10;
+      overflow-y: auto;
     }
   }
 


### PR DESCRIPTION
This patch also does a couple of other small layout cleanups while I was in this code.

* make the modal dynamically re-size itself vertically (previously, it would set the max height at popup time, but then if the window was resized, it wouldn't adjust)
* make the "severity" row in the details view colorized
* fix the JSON tab to not waste extra space and do nicer scroll bar boundaries