### PR TITLE
HELM-149: theme support for alarm table severities

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "mini-css-extract-plugin": "^0.5.0",
     "mocha": "^5.2.0",
     "node-sass": "^4.12.0",
+    "opennms-style": "https://github.com/OpenNMS/opennms-style.git#v0.1.0",
     "parallel-webpack": "^2.3.0",
     "prunk": "^1.3.0",
     "recursive-copy": "^2.0.6",

--- a/src/panels/alarm-table/alarm_details.html
+++ b/src/panels/alarm-table/alarm_details.html
@@ -1,4 +1,4 @@
-<div class="modal-body alarm-details" style="overflow: auto;" dynamic-height>
+<div class="modal-body alarm-details" style="overflow: auto;" dynamic-height ng-class="'opennms-theme-' + (ctrl.panel.theme ? ctrl.panel.theme : 'helm')">
     <div class="modal-header">
         <h2 class="modal-header-title">
             <a href="{{ alarm.detailsPage }}" target="_blank"><i class="fa fa-external-link"></i></a>

--- a/src/panels/alarm-table/editor.html
+++ b/src/panels/alarm-table/editor.html
@@ -58,13 +58,23 @@
         <h5 class="section-heading">Alarms</h5>
         <div class="gf-form max-width-20">
             <label class="gf-form-label width-10">Style with severity</label>
-            <div class="gf-form-select-wrapper width-8">
+            <div class="gf-form-select-wrapper width-12">
                 <select class="gf-form-input"
                         ng-model="editor.panel.severity"
                         ng-change="editor.render()">
                     <option value="row">Row</option>
                     <option value="column">Column</option>
                     <option value="off">Off</option>
+                </select>
+            </div>
+        </div>
+        <div class="gf-form max-width-20">
+            <label class="gf-form-label width-10">Severity theme</label>
+            <div class="gf-form-select-wrapper width-12">
+                <select class="gf-form-input"
+                        ng-model="editor.panel.theme"
+                        ng-options="key as value for (key, value) in editor.themes"
+                        ng-change="editor.render()">
                 </select>
             </div>
         </div>

--- a/src/panels/alarm-table/editor.js
+++ b/src/panels/alarm-table/editor.js
@@ -14,6 +14,16 @@ export class TablePanelEditorCtrl {
     this.transformers = transformers;
     this.fontSizes = ['80%', '90%', '100%', '110%', '120%', '130%', '150%', '160%', '180%', '200%', '220%', '250%'];
 
+    this.themes = {
+      helm: 'Helm Default',
+      opennms: 'OpenNMS',
+      omi: 'OMi',
+    };
+
+    if (!this.themes[this.panel.theme]) {
+      this.panel.theme = 'helm';
+    }
+
     this.srcIndex = undefined;
     this.destIndex = undefined;
 

--- a/src/panels/alarm-table/module.html
+++ b/src/panels/alarm-table/module.html
@@ -1,4 +1,4 @@
-<div class="table-panel-container">
+<div class="table-panel-container" ng-class="'opennms-theme-' + (ctrl.panel.theme ? ctrl.panel.theme : 'helm')">
     <div class="table-panel-header-bg" ng-show="ctrl.table.rows.length"></div>
     <div class="table-panel-scroll" ng-style="!ctrl.panel.scroll && {'overflow': 'visible'}" ng-show="ctrl.table.rows.length">
         <table class="table-panel-table dense-table-panel-table alarm-table">

--- a/src/panels/alarm-table/sass/_severity-themes.scss
+++ b/src/panels/alarm-table/sass/_severity-themes.scss
@@ -1,0 +1,69 @@
+@import '~opennms-style/opennms';
+
+// If you add a theme here, you must also give it an entry in
+// alarm-table/editor.js for the editor drop-down.
+
+$severity-themes: (
+  'helm': (
+    'cleared': #EEE000,
+    'indeterminate': #990000,
+    'normal': #86B15B,
+    'warning': #FCCC3B,
+    'minor': #EE901C,
+    'major': #E3692F,
+    'critical': #DB4345,
+  ),
+  'opennms': (
+    'cleared': $opennms-severity-cleared-dark,
+    'indeterminate': $opennms-severity-indeterminate-dark,
+    'normal': $opennms-severity-normal-dark,
+    'warning': $opennms-severity-warning-dark,
+    'minor': $opennms-severity-minor-dark,
+    'major': $opennms-severity-major-dark,
+    'critical': $opennms-severity-critical-dark,
+  ),
+  'omi': (
+    'cleared': #cccccc,
+    'indeterminate': #00d3c9,
+    'normal': #00d3c9,
+    'warning': #00d3c9,
+    'minor': #ffce56,
+    'major': #ff9033,
+    'critical': #ff3b50,
+  ),
+) !default;
+
+@mixin opennms-themify($property, $lighten, $key, $themes: $severity-themes) {
+  @each $theme, $colors in $themes {
+    $theme-color: null;
+    @if $lighten {
+      $theme-color: lighten(map-get($colors, $key), 25%);
+    }
+    @else {
+      $theme-color: map-get($colors, $key);
+    }
+    &.opennms-theme-#{$theme}, .opennms-theme-#{$theme} & {
+      #{$property}: $theme-color;
+    }
+  }
+}
+
+@mixin severity-color($arguments...) {
+  @include opennms-themify('color', false, $arguments...);
+}
+@mixin severity-background-color($arguments...) {
+  @include opennms-themify('background-color', false, $arguments...);
+}
+@mixin severity-border-color($arguments...) {
+  @include opennms-themify('border-color', false, $arguments...);
+}
+
+@mixin severity-color-light($arguments...) {
+  @include opennms-themify('color', true, $arguments...);
+}
+@mixin severity-background-color-light($arguments...) {
+  @include opennms-themify('background-color', true, $arguments...);
+}
+@mixin severity-border-color-light($arguments...) {
+  @include opennms-themify('border-color', true, $arguments...);
+}

--- a/src/panels/alarm-table/sass/_table.scss
+++ b/src/panels/alarm-table/sass/_table.scss
@@ -98,13 +98,13 @@ td.onms-checkbox {
 }
 
 $severity-font-weight: normal;
-$cleared-color: #CCCCCC;
-$indeterminate-color: #8080EE;
-$normal-color: #99BF73;
-$warning-color: #FFCC00;
-$minor-color: #FF8600;
-$major-color: #EE1E00;
-$critical-color: #B50322;
+$indeterminate-color: #990000;
+$cleared-color: #EEE000;
+$normal-color: #86B15B;
+$warning-color: #FCCC3B;
+$minor-color: #EE901C;
+$major-color: #E3692F;
+$critical-color: #DB4345;
 
 .severity {
   .indeterminate {

--- a/src/panels/alarm-table/sass/_table.scss
+++ b/src/panels/alarm-table/sass/_table.scss
@@ -2,6 +2,7 @@ $ionicons-font-path: '../../../../node_modules/ionicons/fonts';
 
 @import '~ionicons/scss/ionicons';
 @import 'colors';
+@import 'severity-themes';
 
 $padding-small: 0.25em;
 $padding-large: 0.50em;
@@ -98,53 +99,46 @@ td.onms-checkbox {
 }
 
 $severity-font-weight: normal;
-$indeterminate-color: #990000;
-$cleared-color: #EEE000;
-$normal-color: #86B15B;
-$warning-color: #FCCC3B;
-$minor-color: #EE901C;
-$major-color: #E3692F;
-$critical-color: #DB4345;
 
 .severity {
   .indeterminate {
-    background-color: $indeterminate-color;
+    @include severity-background-color('indeterminate');
     color: $cell-text-color;
     font-weight: $severity-font-weight;
   }
 
   .cleared {
-    background-color: $cleared-color;
+    @include severity-background-color('cleared');
     color: $cell-text-color;
     font-weight: $severity-font-weight;
   }
 
   .normal {
-    background-color: $normal-color;
+    @include severity-background-color('normal');
     color: $cell-text-color;
     font-weight: $severity-font-weight;
   }
 
   .warning {
-    background-color: $warning-color;
+    @include severity-background-color('warning');
     color: $cell-text-color;
     font-weight: $severity-font-weight;
   }
 
   .minor {
-    background-color: $minor-color;
+    @include severity-background-color('minor');
     color: $cell-text-color;
     font-weight: $severity-font-weight;
   }
 
   .major {
-    background-color: $major-color;
+    @include severity-background-color('major');
     color: $cell-text-color;
     font-weight: $severity-font-weight;
   }
 
   .critical {
-    background-color: $critical-color;
+    @include severity-background-color('critical');
     color: $cell-text-color;
     font-weight: $severity-font-weight;
   }
@@ -169,32 +163,37 @@ $critical-color: #DB4345;
   background-color: $selected-cell-no-severity-background-color;
 }
 
-.alarm-table > .severity > .indeterminate {
-  background-color: lighten($indeterminate-color, 25%);
+@mixin severity-highlight($severity) {
+  @include severity-background-color-light($severity);
+  color: $cell-dark-color;
 }
 
-.alarm-table > .severity > .selected.cleared {
-  background-color: lighten($cleared-color, 25%);
+.alarm-table .severity .selected .indeterminate {
+  @include severity-highlight('indeterminate');
 }
 
-.alarm-table >.severity > .selected.normal {
-  background-color: lighten($normal-color, 25%);
+.alarm-table .severity .selected .cleared {
+  @include severity-highlight('cleared');
 }
 
-.alarm-table > .severity > .selected.warning {
-  background-color: lighten($warning-color, 25%);
+.alarm-table .severity .selected .normal {
+  @include severity-highlight('normal');
 }
 
-.alarm-table > .severity > .selected.minor {
-  background-color: lighten($minor-color, 25%);
+.alarm-table .severity .selected .warning {
+  @include severity-highlight('warning');
 }
 
-.alarm-table > .severity > .selected.major {
-  background-color: lighten($major-color, 25%);
+.alarm-table .severity .selected .minor {
+  @include severity-highlight('minor');
 }
 
-.alarm-table > .severity > .selected.critical {
-  background-color: lighten($critical-color, 35%);
+.alarm-table .severity .selected .major {
+  @include severity-highlight('major');
+}
+
+.alarm-table .severity .selected .critical {
+  @include severity-highlight('critical');
 }
 
 .alarm-table tr.next-selected td {
@@ -237,31 +236,31 @@ $critical-color: #DB4345;
 }
 
 .alarm-table tr.indeterminate:hover {
-  background-color: lighten($indeterminate-color, 25%);
+  @include severity-highlight('indeterminate');
 }
 
 .alarm-table tr.cleared:hover {
-  background-color: lighten($cleared-color, 25%);
+  @include severity-highlight('cleared');
 }
 
 .alarm-table tr.normal:hover {
-  background-color: lighten($normal-color, 25%);
+  @include severity-highlight('normal');
 }
 
 .alarm-table tr.warning:hover {
-  background-color: lighten($warning-color, 25%);
+  @include severity-highlight('warning');
 }
 
 .alarm-table tr.minor:hover {
-  background-color: lighten($minor-color, 25%);
+  @include severity-highlight('minor');
 }
 
 .alarm-table tr.major:hover {
-  background-color: lighten($major-color, 25%);
+  @include severity-highlight('major');
 }
 
 .alarm-table tr.critical:hover {
-  background-color: lighten($critical-color, 25%);
+  @include severity-highlight('critical');
 }
 
 .gf-form-no-margin {

--- a/yarn.lock
+++ b/yarn.lock
@@ -5134,6 +5134,10 @@ opener@^1.5.1:
   resolved "https://registry.yarnpkg.com/opener/-/opener-1.5.1.tgz#6d2f0e77f1a0af0032aca716c2c1fbb8e7e8abed"
   integrity sha512-goYSy5c2UXE4Ra1xixabeVh1guIX/ZV/YokJksb6q2lubWu6UbvPQ20p542/sFIll1nl8JnCyK9oBaOcCWXwvA==
 
+"opennms-style@https://github.com/OpenNMS/opennms-style.git#v0.1.0":
+  version "0.1.0"
+  resolved "https://github.com/OpenNMS/opennms-style.git#30ceb541093d2e326bdeb7199270abfaff7debe5"
+
 opennms@1.4.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/opennms/-/opennms-1.4.0.tgz#47a668bd40ec4a3026e7c7a6af746e7990e4ed43"


### PR DESCRIPTION
This PR adds theme support for alarm table severities.  It has 3 default themes: "Helm Default" (existing helm theme), "OpenNMS" (matches OpenNMS Horizon 24's colors), and "OMi".