### PR TITLE
HZN-1559,HZN-1570,HZN-1571: Drift 2.0 API Enhancements Frontend Work

### DIFF
--- a/src/datasources/flow-ds/flow_functions.js
+++ b/src/datasources/flow-ds/flow_functions.js
@@ -47,6 +47,45 @@ addFuncDef({
   params: [{name: "ifIndex", type: "int"}]
 });
 
+
+addFuncDef({
+  name: 'withApplication',
+  category: categories.Filter,
+  appliesToSegments: ['applications'],
+  params: [{
+    name: "application",
+    type: "string",
+    options: (input, ctx) => {
+      return ctx.client.getApplications(input, ctx.getStartTime(), ctx.getEndTime(), ctx.getNodeCriteria(),
+          ctx.getInterfaceId());
+    }
+  }]
+});
+
+addFuncDef({
+  name: 'withHost',
+  category: categories.Filter,
+  appliesToSegments: ['hosts'],
+  params: [{
+    name: "host",
+    type: "string",
+    options: (input, ctx) => {
+      return ctx.client.getHosts(input, ctx.getStartTime(), ctx.getEndTime(), ctx.getNodeCriteria(),
+          ctx.getInterfaceId());
+    }
+  }]
+});
+
+addFuncDef({
+  name: 'withConversation',
+  category: categories.Filter,
+  appliesToSegments: ['conversations'],
+  params: [{
+    name: "conversation",
+    type: "string"
+  }]
+});
+
 // Transform
 
 addFuncDef({

--- a/src/datasources/flow-ds/partials/query.editor.html
+++ b/src/datasources/flow-ds/partials/query.editor.html
@@ -10,7 +10,7 @@
       </div>
 
       <div class="gf-form dropdown">
-        <span opennms-add-func></span>
+        <span opennms-add-func ctrl="ctrl" segment-metric="{{ctrl.segments[0].value}}"></span>
       </div>
 
       <div class="gf-form gf-form--grow">

--- a/src/datasources/flow-ds/query_ctrl.js
+++ b/src/datasources/flow-ds/query_ctrl.js
@@ -52,8 +52,9 @@ export class FlowDatasourceQueryCtrl extends QueryCtrl {
 
   getAltSegments() {
     return Promise.resolve([
+      {value: 'applications'},
       {value: 'conversations'},
-      {value: 'applications'}
+      {value: 'hosts'}
     ]);
   }
 

--- a/src/lib/client_delegate.js
+++ b/src/lib/client_delegate.js
@@ -296,7 +296,15 @@ export class ClientDelegate {
     getSeriesForTopNConversations(N, start, end, step, includeOther, nodeCriteria, interfaceId) {
         return this.getFlowDao()
             .then(function(flowDao) {
-                return flowDao.getSeriesForTopNConversations({N: N, includeOther: includeOther}, start, end, step, nodeCriteria, interfaceId);
+                return flowDao.getSeriesForTopNConversations({
+                    N: N,
+                    start: start,
+                    end: end,
+                    step: step,
+                    nodeCriteria: nodeCriteria,
+                    interfaceId: interfaceId,
+                    includeOther: includeOther
+                });
             }).catch(this.decorateError);
     }
 
@@ -310,7 +318,14 @@ export class ClientDelegate {
     getSummaryForTopNConversations(N, start, end, includeOther, nodeCriteria, interfaceId) {
         return this.getFlowDao()
             .then(function(flowDao) {
-                return flowDao.getSummaryForTopNConversations({N: N, includeOther: includeOther}, start, end, nodeCriteria, interfaceId);
+                return flowDao.getSummaryForTopNConversations({
+                    N: N,
+                    start: start,
+                    end: end,
+                    nodeCriteria: nodeCriteria,
+                    interfaceId: interfaceId,
+                    includeOther: includeOther
+                });
             }).catch(this.decorateError);
     }
 

--- a/src/lib/client_delegate.js
+++ b/src/lib/client_delegate.js
@@ -258,6 +258,13 @@ export class ClientDelegate {
         }).catch(this.decorateError);
     }
 
+    getApplications(prefix, start, end, nodeCriteria, interfaceId) {
+        return this.getFlowDao()
+            .then(function(flowDao) {
+                return flowDao.getApplications(prefix, start, end, nodeCriteria, interfaceId);
+            }).catch(this.decorateError);
+    }
+
     getSeriesForTopNApplications(N, start, end, step, includeOther, nodeCriteria, interfaceId) {
         return this.getFlowDao()
             .then(function(flowDao) {
@@ -265,10 +272,10 @@ export class ClientDelegate {
             }).catch(this.decorateError);
     }
 
-    getSeriesForTopNConversations(N, start, end, step, nodeCriteria, interfaceId) {
+    getSeriesForApplications(applications, start, end, step, includeOther, nodeCriteria, interfaceId) {
         return this.getFlowDao()
             .then(function(flowDao) {
-                return flowDao.getSeriesForTopNConversations(N, start, end, step, nodeCriteria, interfaceId);
+                return flowDao.getSeriesForApplications(applications, start, end, step, includeOther, nodeCriteria, interfaceId);
             }).catch(this.decorateError);
     }
 
@@ -279,10 +286,73 @@ export class ClientDelegate {
             }).catch(this.decorateError);
     }
 
-    getSummaryForTopNConversations(N, start, end, nodeCriteria, interfaceId) {
+    getSummaryForApplications(applications, start, end, includeOther, nodeCriteria, interfaceId) {
         return this.getFlowDao()
             .then(function(flowDao) {
-                return flowDao.getSummaryForTopNConversations(N, start, end, nodeCriteria, interfaceId);
+                return flowDao.getSummaryForApplications(applications, start, end, includeOther, nodeCriteria, interfaceId);
+            }).catch(this.decorateError);
+    }
+
+    getSeriesForTopNConversations(N, start, end, step, includeOther, nodeCriteria, interfaceId) {
+        return this.getFlowDao()
+            .then(function(flowDao) {
+                return flowDao.getSeriesForTopNConversations(N, start, end, step, includeOther, nodeCriteria, interfaceId);
+            }).catch(this.decorateError);
+    }
+
+    getSeriesForConversations(conversations, start, end, step, includeOther, nodeCriteria, interfaceId) {
+        return this.getFlowDao()
+            .then(function(flowDao) {
+                return flowDao.getSeriesForConversations(conversations, start, end, step, includeOther, nodeCriteria, interfaceId);
+            }).catch(this.decorateError);
+    }
+
+    getSummaryForTopNConversations(N, start, end, includeOther, nodeCriteria, interfaceId) {
+        return this.getFlowDao()
+            .then(function(flowDao) {
+                return flowDao.getSummaryForTopNConversations(N, start, end, includeOther, nodeCriteria, interfaceId);
+            }).catch(this.decorateError);
+    }
+
+    getSummaryForConversations(conversations, start, end, includeOther, nodeCriteria, interfaceId) {
+        return this.getFlowDao()
+            .then(function(flowDao) {
+                return flowDao.getSummaryForConversations(conversations, start, end, includeOther, nodeCriteria, interfaceId);
+            }).catch(this.decorateError);
+    }
+
+    getHosts(prefix, start, end, nodeCriteria, interfaceId) {
+        return this.getFlowDao()
+            .then(function(flowDao) {
+                return flowDao.getHosts(prefix + '.*', start, end, nodeCriteria, interfaceId);
+            }).catch(this.decorateError);
+    }
+
+    getSeriesForHosts(hosts, start, end, step, includeOther, nodeCriteria, interfaceId) {
+        return this.getFlowDao()
+            .then(function(flowDao) {
+                return flowDao.getSeriesForHosts(hosts, start, end, step, includeOther, nodeCriteria, interfaceId);
+            }).catch(this.decorateError);
+    }
+
+    getSeriesForTopNHosts(N, start, end, step, includeOther, nodeCriteria, interfaceId) {
+        return this.getFlowDao()
+            .then(function(flowDao) {
+                return flowDao.getSeriesForTopNHosts(N, start, end, step, includeOther, nodeCriteria, interfaceId);
+            }).catch(this.decorateError);
+    }
+
+    getSummaryForTopNHosts(N, start, end, includeOther, nodeCriteria, interfaceId) {
+        return this.getFlowDao()
+            .then(function(flowDao) {
+                return flowDao.getSummaryForTopNHosts(N, start, end, includeOther, nodeCriteria, interfaceId);
+            }).catch(this.decorateError);
+    }
+
+    getSummaryForHosts(hosts, start, end, includeOther, nodeCriteria, interfaceId) {
+        return this.getFlowDao()
+            .then(function(flowDao) {
+                return flowDao.getSummaryForHosts(hosts, start, end, includeOther, nodeCriteria, interfaceId);
             }).catch(this.decorateError);
     }
 

--- a/src/lib/client_delegate.js
+++ b/src/lib/client_delegate.js
@@ -296,7 +296,7 @@ export class ClientDelegate {
     getSeriesForTopNConversations(N, start, end, step, includeOther, nodeCriteria, interfaceId) {
         return this.getFlowDao()
             .then(function(flowDao) {
-                return flowDao.getSeriesForTopNConversations(N, start, end, step, includeOther, nodeCriteria, interfaceId);
+                return flowDao.getSeriesForTopNConversations({N: N, includeOther: includeOther}, start, end, step, nodeCriteria, interfaceId);
             }).catch(this.decorateError);
     }
 
@@ -310,7 +310,7 @@ export class ClientDelegate {
     getSummaryForTopNConversations(N, start, end, includeOther, nodeCriteria, interfaceId) {
         return this.getFlowDao()
             .then(function(flowDao) {
-                return flowDao.getSummaryForTopNConversations(N, start, end, includeOther, nodeCriteria, interfaceId);
+                return flowDao.getSummaryForTopNConversations({N: N, includeOther: includeOther}, start, end, nodeCriteria, interfaceId);
             }).catch(this.decorateError);
     }
 


### PR DESCRIPTION
Drift 2.0 API Enhancements Frontend Work

This PR updates Helm to provide filtering based on the enhanced flow API in Opennms.

Filtering based on host:
![Screen Shot 2019-05-30 at 3 07 12 PM](https://user-images.githubusercontent.com/595194/58660100-95e4b100-82f2-11e9-9a57-bb8f99ad0438.png)

Filtering based on application:
![Screen Shot 2019-05-30 at 3 06 32 PM](https://user-images.githubusercontent.com/595194/58660090-911ffd00-82f2-11e9-9c46-54b7e8513dce.png)

Filtering based on conversation key:
![Screen Shot 2019-05-30 at 3 08 35 PM](https://user-images.githubusercontent.com/595194/58660114-9ed58280-82f2-11e9-93cf-a38374cec572.png)

The new filter functions are only presented when the appropriate segment/metric is selected (application, host, conversation).

Autocomplete is presented for the host and application filters. The autocomplete takes into account the context of the time range currently selected as well as the exporter node and interface Ids if set.

For conversation filtering it is expected that this will be set in the future by a dynamically populated variable and there is no auto complete currently.

I've tested this manually for all the filtering cases for the graphed data as well as the table summary data.

Jira issues:
https://issues.opennms.org/browse/HZN-1571
https://issues.opennms.org/browse/HZN-1570
https://issues.opennms.org/browse/HZN-1559