### PR TITLE
HELM-148: Control resolution when using the flow datasource

### DIFF
--- a/docs/datasources/flow_datasource.adoc
+++ b/docs/datasources/flow_datasource.adoc
@@ -21,6 +21,8 @@ The query editor supports the following functions:
 | Transform | `combineIngressEgress`  | Sum ingress and egress values together.
 | Transform | `onlyIngress`           | Only display ingress traffic.
 | Transform | `onlyEgress`            | Only display egress traffic.
+| Transform | `withGroupByInterval`   | Changes the resolution of the returned datapoints grouping by the given time
+interval (in the format of: 10s, 5m, 1h etc...)
 |===
 
 == Template Queries

--- a/src/datasources/flow-ds/datasource.js
+++ b/src/datasources/flow-ds/datasource.js
@@ -370,7 +370,7 @@ export class FlowDatasource {
       return def;
     }
     // Return the parameter value, and perform any required template variable substitutions
-    if (Gfuncs.getFuncDef(name).params[0].type === 'int') {
+    if (Gfuncs.getFuncDef(name).params[idx].type === 'int') {
       return func.parameters[idx];
     } else {
       return this.templateSrv.replace(func.parameters[idx]);

--- a/src/datasources/flow-ds/flow_functions.js
+++ b/src/datasources/flow-ds/flow_functions.js
@@ -19,17 +19,25 @@ function addFuncDef(funcDef) {
   index[funcDef.shortName || funcDef.name] = funcDef;
 }
 
+export const Cardinality = Object.freeze({
+  SINGLE: "single",
+  MULTIPLE: "multiple"
+});
+
 // Combine
 
 addFuncDef({
   name: 'topN',
   category: categories.Combine,
+  cardinality: Cardinality.SINGLE,
+  mutuallyExcludes: ['withApplication', 'withHost', 'withConversation'],
   params: [{name: "n", type: "int",}],
   defaultParams: [10]
 });
 
 addFuncDef({
   name: 'includeOther',
+  cardinality: Cardinality.SINGLE,
   category: categories.Combine
 });
 
@@ -38,12 +46,14 @@ addFuncDef({
 addFuncDef({
   name: 'withExporterNode',
   category: categories.Filter,
+  cardinality: Cardinality.SINGLE,
   params: [{name: "nodeCriteria", type: "string"}]
 });
 
 addFuncDef({
   name: 'withIfIndex',
   category: categories.Filter,
+  cardinality: Cardinality.SINGLE,
   params: [{name: "ifIndex", type: "int"}]
 });
 
@@ -51,6 +61,7 @@ addFuncDef({
 addFuncDef({
   name: 'withApplication',
   category: categories.Filter,
+  mutuallyExcludes: ['topN'],
   appliesToSegments: ['applications'],
   params: [{
     name: "application",
@@ -65,6 +76,7 @@ addFuncDef({
 addFuncDef({
   name: 'withHost',
   category: categories.Filter,
+  mutuallyExcludes: ['topN'],
   appliesToSegments: ['hosts'],
   params: [{
     name: "host",
@@ -79,6 +91,7 @@ addFuncDef({
 addFuncDef({
   name: 'withConversation',
   category: categories.Filter,
+  mutuallyExcludes: ['topN'],
   appliesToSegments: ['conversations'],
   params: [{
     name: "conversation",
@@ -90,42 +103,60 @@ addFuncDef({
 
 addFuncDef({
   name: 'perSecond',
+  cardinality: Cardinality.SINGLE,
   category: categories.Transform
 });
 
 addFuncDef({
   name: 'toBits',
+  cardinality: Cardinality.SINGLE,
   category: categories.Transform
 });
 
 addFuncDef({
   name: 'negativeEgress',
+  cardinality: Cardinality.SINGLE,
   category: categories.Transform
 });
 
 addFuncDef({
   name: 'negativeIngress',
+  cardinality: Cardinality.SINGLE,
   category: categories.Transform
 });
 
 addFuncDef({
   name: 'asTableSummary',
+  cardinality: Cardinality.SINGLE,
   category: categories.Transform
 });
 
 addFuncDef({
   name: 'combineIngressEgress',
+  cardinality: Cardinality.SINGLE,
   category: categories.Transform
 });
 
 addFuncDef({
   name: 'onlyIngress',
+  cardinality: Cardinality.SINGLE,
   category: categories.Transform
 });
 
 addFuncDef({
   name: 'onlyEgress',
+  cardinality: Cardinality.SINGLE,
   category: categories.Transform
+});
+
+addFuncDef({
+  name: 'withGroupByInterval',
+  category: categories.Transform,
+  cardinality: Cardinality.SINGLE,
+  params: [{
+    name: "interval",
+    type: "string"
+  }]
 });
 
 _.each(categories, function (funcList, catName) {

--- a/src/datasources/flow-ds/flow_functions.js
+++ b/src/datasources/flow-ds/flow_functions.js
@@ -104,48 +104,57 @@ addFuncDef({
 addFuncDef({
   name: 'perSecond',
   cardinality: Cardinality.SINGLE,
+  mutuallyExcludes: ['asTableSummary'],
   category: categories.Transform
 });
 
 addFuncDef({
   name: 'toBits',
   cardinality: Cardinality.SINGLE,
+  mutuallyExcludes: ['asTableSummary'],
   category: categories.Transform
 });
 
 addFuncDef({
   name: 'negativeEgress',
   cardinality: Cardinality.SINGLE,
+  mutuallyExcludes: ['asTableSummary'],
   category: categories.Transform
 });
 
 addFuncDef({
   name: 'negativeIngress',
   cardinality: Cardinality.SINGLE,
+  mutuallyExcludes: ['asTableSummary'],
   category: categories.Transform
 });
 
 addFuncDef({
   name: 'asTableSummary',
   cardinality: Cardinality.SINGLE,
+  mutuallyExcludes: ['perSecond', 'toBits', 'negativeEgress', 'negativeIngress', 'combineIngressEgress', 'onlyIngress',
+    'onlyEgress', 'withGroupByInterval'],
   category: categories.Transform
 });
 
 addFuncDef({
   name: 'combineIngressEgress',
   cardinality: Cardinality.SINGLE,
+  mutuallyExcludes: ['asTableSummary'],
   category: categories.Transform
 });
 
 addFuncDef({
   name: 'onlyIngress',
   cardinality: Cardinality.SINGLE,
+  mutuallyExcludes: ['asTableSummary'],
   category: categories.Transform
 });
 
 addFuncDef({
   name: 'onlyEgress',
   cardinality: Cardinality.SINGLE,
+  mutuallyExcludes: ['asTableSummary'],
   category: categories.Transform
 });
 
@@ -153,6 +162,7 @@ addFuncDef({
   name: 'withGroupByInterval',
   category: categories.Transform,
   cardinality: Cardinality.SINGLE,
+  mutuallyExcludes: ['asTableSummary'],
   params: [{
     name: "interval",
     type: "string"

--- a/src/datasources/flow-ds/flow_functions.js
+++ b/src/datasources/flow-ds/flow_functions.js
@@ -111,7 +111,6 @@ addFuncDef({
 addFuncDef({
   name: 'toBits',
   cardinality: Cardinality.SINGLE,
-  mutuallyExcludes: ['asTableSummary'],
   category: categories.Transform
 });
 
@@ -132,7 +131,7 @@ addFuncDef({
 addFuncDef({
   name: 'asTableSummary',
   cardinality: Cardinality.SINGLE,
-  mutuallyExcludes: ['perSecond', 'toBits', 'negativeEgress', 'negativeIngress', 'combineIngressEgress', 'onlyIngress',
+  mutuallyExcludes: ['perSecond', 'negativeEgress', 'negativeIngress', 'combineIngressEgress', 'onlyIngress',
     'onlyEgress', 'withGroupByInterval'],
   category: categories.Transform
 });

--- a/src/spec/test-main.js
+++ b/src/spec/test-main.js
@@ -13,6 +13,14 @@ prunk.mock('app/plugins/sdk', {
 prunk.mock('app/core/app_events', {
   appEvents: null
 });
+prunk.mock('app/core/utils/kbn', {
+  interval_to_ms: (str) => {return 0;}
+});
+prunk.mock('angular', {
+  $: {
+    isNumeric: (arg) => {return true;}
+  }
+});
 
 // Setup jsdom
 // Required for loading angularjs


### PR DESCRIPTION
- Allow user to override the step to group results by a given interval in string format (10s, 5m, 1h etc...)
- Added cardinality to functions to prevent those that are to be applied only once from being presented in the menu after already being applied
- Added mutual exclusions to functions to prevent conflicting functions from being applied (such as topN and withApplication)

This screenshot shows the new transform function to apply the interval `withGroupByInterval` and the function being excluded from the menu due to cardinality of single.
![Screen Shot 2019-06-03 at 3 55 54 PM](https://user-images.githubusercontent.com/595194/58830376-2df6d900-8618-11e9-931e-3a7e03393931.png)


* Temporarily based on top of the other drift2.0 work, will re-target when that is in

Jira: https://issues.opennms.org/browse/HELM-148