### PR TITLE
Bug Fix - Template variable substitution was broken for int functions

### DIFF
--- a/src/datasources/flow-ds/datasource.js
+++ b/src/datasources/flow-ds/datasource.js
@@ -1,7 +1,6 @@
 import _ from 'lodash';
 import {ClientDelegate} from '../../lib/client_delegate';
 import kbn from 'app/core/utils/kbn';
-import {Gfuncs} from "./flow_functions";
 
 export class FlowDatasource {
   /** @ngInject */
@@ -384,11 +383,12 @@ export class FlowDatasource {
       // No match, use the default value
       return def;
     }
+
     // Return the parameter value, and perform any required template variable substitutions
-    if (Gfuncs.getFuncDef(name).params[idx].type === 'int') {
-      return func.parameters[idx];
-    } else {
+    if (isNaN(func.parameters[idx])) {
       return this.templateSrv.replace(func.parameters[idx]);
+    } else {
+      return func.parameters[idx];
     }
   }
 

--- a/src/datasources/flow-ds/datasource.js
+++ b/src/datasources/flow-ds/datasource.js
@@ -385,7 +385,7 @@ export class FlowDatasource {
     }
 
     // Return the parameter value, and perform any required template variable substitutions
-    if (isNaN(func.parameters[idx])) {
+    if (_.isString(func.parameters[idx])) {
       return this.templateSrv.replace(func.parameters[idx]);
     } else {
       return func.parameters[idx];


### PR DESCRIPTION
This PR fixes an issue introduced by my previous PR where template variable substitution stopped working for functions that took int values.