### PR TITLE
HELM-163: Enhance CircleCI workflow to capture test metadata for Helm

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -43,6 +43,9 @@ jobs:
             - yarn-packages-{{ .Branch }}
             - yarn-packages-
       - run:
+          name: Install Test Dependencies
+          command: npm install mocha-junit-reporter
+      - run:
           name: Install Yarn Dependencies
           command: yarn install --pure-lockfile
       - save_cache:
@@ -51,19 +54,18 @@ jobs:
           paths:
             - node_modules/
       - run:
-          name: Install Test Dependencies
-          command: npm install mocha-junit-reporter
-      - run:
           name: Run Build
           command: yarn build
       - run:
           name: Run Tests
           command: |
-              mkdir -p ~/reports/mocha
-              mkdir -p ~/reports/eslint
+              mkdir -p reports/mocha
+              mkdir -p reports/eslint
               yarn test-circleci
-              yarn eslint-circieci
+              yarn eslint-circleci
       - store_test_results:
+          path: reports
+      - store_artifacts:
           path: reports
       - persist_to_workspace:
           root: *working_directory

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -51,11 +51,20 @@ jobs:
           paths:
             - node_modules/
       - run:
+          name: Install Test Dependencies
+          command: npm install mocha-junit-reporter
+      - run:
           name: Run Build
           command: yarn build
       - run:
           name: Run Tests
-          command: yarn test
+          command: |
+              mkdir -p ~/reports/mocha
+              mkdir -p ~/reports/eslint
+              yarn test-circleci
+              yarn eslint-circieci
+      - store_test_results:
+          path: reports
       - persist_to_workspace:
           root: *working_directory
           paths:

--- a/package.json
+++ b/package.json
@@ -58,6 +58,7 @@
     "flot-axislabels": "https://github.com/j-white/flot-axislabels#master",
     "ionicons": "2.0.1",
     "lodash": "^4.17.11",
+    "mocha-junit-reporter": "^1.23.0",
     "opennms": "1.5.0",
     "parenthesis": "^3.1.5",
     "q": "^1.5.0"
@@ -87,9 +88,9 @@
     "dev": "webpack --mode=development",
     "build": "webpack --mode=production --optimize-minimize --optimize-dedupe",
     "eslint": "eslint 'src/**/*.js'",
-    "eslint-circleci": "eslint 'src/**/*.js' --format junit --output-file ~/reports/eslint/eslint.xml",
+    "eslint-circleci": "eslint 'src/**/*.js' --format junit --output-file reports/eslint/eslint.xml",
     "test": "mocha --require @babel/register --require jsdom-global/register --require src/spec/test-main.js src/spec/*.js",
-    "test-circleci": "mocha --require @babel/register --require jsdom-global/register --require src/spec/test-main.js src/spec/*.js --reporter mocha-junit-reporter --reporter-options mochaFile=~/reports/mocha/test-results.xml",
+    "test-circleci": "mocha --require @babel/register --require jsdom-global/register --require src/spec/test-main.js src/spec/*.js --reporter mocha-junit-reporter --reporter-options mochaFile=reports/mocha/test-results.xml",
     "watch": "webpack --mode=development --watch",
     "watch-test": "mocha --watch --require @babel/register --require jsdom-global/register --require src/spec/test-main.js src/spec/*.js"
   }

--- a/package.json
+++ b/package.json
@@ -87,7 +87,9 @@
     "dev": "webpack --mode=development",
     "build": "webpack --mode=production --optimize-minimize --optimize-dedupe",
     "eslint": "eslint 'src/**/*.js'",
+    "eslint-circleci": "eslint 'src/**/*.js' --format junit --output-file ~/reports/eslint/eslint.xml",
     "test": "mocha --require @babel/register --require jsdom-global/register --require src/spec/test-main.js src/spec/*.js",
+    "test-circleci": "mocha --require @babel/register --require jsdom-global/register --require src/spec/test-main.js src/spec/*.js --reporter mocha-junit-reporter --reporter-options mochaFile=~/reports/mocha/test-results.xml",
     "watch": "webpack --mode=development --watch",
     "watch-test": "mocha --watch --require @babel/register --require jsdom-global/register --require src/spec/test-main.js src/spec/*.js"
   }

--- a/package.json
+++ b/package.json
@@ -58,7 +58,6 @@
     "flot-axislabels": "https://github.com/j-white/flot-axislabels#master",
     "ionicons": "2.0.1",
     "lodash": "^4.17.11",
-    "mocha-junit-reporter": "^1.23.0",
     "opennms": "1.5.0",
     "parenthesis": "^3.1.5",
     "q": "^1.5.0"

--- a/src/panels/flow-histogram/ctrl.js
+++ b/src/panels/flow-histogram/ctrl.js
@@ -1,3 +1,4 @@
+/*eslint no-unused-vars: "warn"*/
 import {MetricsPanelCtrl} from "app/plugins/sdk";
 import _ from "lodash";
 import $ from "jquery";

--- a/src/spec/test-main.js
+++ b/src/spec/test-main.js
@@ -1,3 +1,4 @@
+/*eslint no-unused-vars: "warn"*/
 import prunk from 'prunk';
 import jsdom from 'jsdom';
 import chai from 'chai';


### PR DESCRIPTION
HELM-163: Enhance CircleCI workflow to capture test metadata for Helm
* Add two new script targets "eslint-circleci" and "test-circleci" for circleci tests
* Convert mocha tests to output for circleci capture
* Convert eslint tests to output for circleci capture

JIRA: https://issues.opennms.org/browse/HELM-163