### PR TITLE
HELM-161: ignore data events that could cause refresh

### DIFF
--- a/src/lib/filter_column.js
+++ b/src/lib/filter_column.js
@@ -29,4 +29,21 @@ export class FilterColumn {
   set text(text) {
     this._text = text;
   }
+
+  toJSON() {
+    return {
+      id: this.id,
+      text: this._text,
+      label: this.label,
+      datasource: this.datasource,
+      resource: this.resource,
+      inputType: this.inputType,
+      entityType: this.entityType,
+      selected: this.selected,
+    };
+  }
+
+  static fromJSON(col) {
+    return new FilterColumn(col.text, col.label, col.datasource, col.resource, col.inputType, col.entityType, col.id, col.selected);
+  }
 }

--- a/src/panels/filter-panel/ctrl.js
+++ b/src/panels/filter-panel/ctrl.js
@@ -41,6 +41,7 @@ class FilterCtrl extends MetricsPanelCtrl {
         this.$scope.dashboard = this.dashboard;
         this.$scope.ctrl = this;
         this.$scope.columnVariables = [];
+        this.panel.columns = this.panel.columns.map((col) => FilterColumn.fromJSON(col));
 
         this.events.on('init-edit-mode', this.onInitEditMode.bind(this));
         this.events.on('render', this.onRender.bind(this));


### PR DESCRIPTION
Since the filter panel only "refreshes" when the variables are pulled down, it should ignore "data" events from the dashboard.  This avoids refreshing resetting things.

# Pull Request Check Sheet

* [x] Have you read and followed our [Contribution Guidelines](https://github.com/OpenNMS/opennms/blob/develop/CONTRIBUTING.md)?
* [x] Have you [made an issue in the OpenNMS issue tracker](https://issues.opennms.org)?<br>If so, you should:
  1. update the title of this PR to be of the format: `${JIRA-ISSUE-NUMBER}: subject of pull request`
  2. update the JIRA link at the bottom of this comment to refer to the real issue number
  3. prefix your commit messages with the issue number, if possible
* [x] Have you made a comment in that issue which points back to this PR?
* [x] Have you updated the JIRA link at the bottom of this comment to link to your issue?
* [ ] If this is a new feature, is there documentation?
* [ ] If this is a new feature or substantial change, are there tests that cover it?

# Pull Request Process

One or more reviewers should be assigned to each PR.

If you know that a particular person is subject matter expert in the area your PR affects, feel free to assign one or more reviewers when you create this PR, otherwise reviewers will be assigned for you.

Once the reviewer(s) accept the PR and the branch passes continuous integration in Bamboo, the PR is eligible for merge.

At that time, if you have commit access (are an OpenNMS Group employee or a member of the Order of the Green Polo) you are welcome to merge the PR.
Otherwise, a reviewer can merge it for you.

Thanks for taking time to contribute!

# External References

* JIRA (Issue Tracker): http://issues.opennms.org/browse/HELM-161
* Continuous Integration: [Bamboo](https://bamboo.opennms.org/), [CircleCI](https://circleci.com/gh/OpenNMS/opennms-js)
