### PR TITLE
HELM-180: Flow Histogram - Not showing Legend

### DIFF
--- a/src/panels/flow-histogram/ctrl.js
+++ b/src/panels/flow-histogram/ctrl.js
@@ -10,7 +10,7 @@ import "jquery.flot.crosshair";
 import "jquery.flot.stack";
 import "flot-axislabels/jquery.flot.axislabels";
 import "flot/jquery.flot.categories";
-
+import "./legend";
 
 class HelmHistogramCtrl extends MetricsPanelCtrl {
     /** @ngInject */


### PR DESCRIPTION
This PR restores the legend to the flow histogram panel.

# Pull Request Check Sheet

* [x] Have you read and followed our [Contribution Guidelines](https://github.com/OpenNMS/opennms/blob/develop/CONTRIBUTING.md)?
* [x] Have you [made an issue in the OpenNMS issue tracker](https://issues.opennms.org)?<br>If so, you should:
  1. update the title of this PR to be of the format: `${JIRA-ISSUE-NUMBER}: subject of pull request`
  2. update the JIRA link at the bottom of this comment to refer to the real issue number
  3. prefix your commit messages with the issue number, if possible
* [x] Have you made a comment in that issue which points back to this PR?
* [x] Have you updated the JIRA link at the bottom of this comment to link to your issue?
* [x] If this is a new feature, is there documentation?
* [x] If this is a new feature or substantial change, are there tests that cover it?

# Pull Request Process

One or more reviewers should be assigned to each PR.

If you know that a particular person is subject matter expert in the area your PR affects, feel free to assign one or more reviewers when you create this PR, otherwise reviewers will be assigned for you.

Once the reviewer(s) accept the PR and the branch passes continuous integration in Bamboo, the PR is eligible for merge.

At that time, if you have commit access (are an OpenNMS Group employee or a member of the Order of the Green Polo) you are welcome to merge the PR.
Otherwise, a reviewer can merge it for you.

Thanks for taking time to contribute!

# External References

* JIRA (Issue Tracker): http://issues.opennms.org/browse/HELM-180
* Continuous Integration: [Bamboo](https://bamboo.opennms.org/), [CircleCI](https://circleci.com/gh/OpenNMS/opennms-js)
