### PR TITLE
HELM-216: Build docs with CircleCI and publish docs to Netlify

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -293,6 +293,5 @@ workflows:
             branches:
               only: 
                 - master
-                - jira/HELM-216
             tags:
               ignore: /^v.*/

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -87,14 +87,26 @@ jobs:
       - run:
           name: Generate documentation as static HTML
           command: asciibinder package -l debug docs
-      
+      - run:
+          name: Create docs tarball 
+          command: |
+            export HELM_VERSION=$(cat version.tag)
+            mkdir -p ./dist/docs
+            tar -czf "./dist/docs/opennms-helm_${HELM_VERSION}.tar.gz" -C docs/_package .
+      - store_artifacts:
+          path: ./dist/docs
+      - persist_to_workspace:
+          root: ~/
+          paths:
+            - ./project/dist/docs
+
   make-tarball:
     executor: build-executor
     steps:
       - attach_workspace:
           at: ~/
       - run:
-          name: Create tarball
+          name: Create plugin tarball
           command: mkdir -p ./dist/packages && tar --exclude='package-lock.json' --exclude='.circleci' --exclude='.git' --exclude='./node_modules' --exclude='./dist/packages' -czf "./dist/packages/opennms-helm_$(cat version.tag).tar.gz" .
       - store_artifacts:
           path: ./dist/packages

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -18,6 +18,10 @@ executors:
     docker:
       - image: opennms/asciibinder
 
+  netlify-cli-executor:
+    docker:
+      - image: opennms/netlify-cli:2.8.3-b1
+
 commands:
   docker-registry-login:
     description: "Connect to Docker Registry"
@@ -222,6 +226,18 @@ jobs:
             docker tag helm:$(cat version.tag) ${DOCKERHUB_PROJECT_USER}/${DOCKERHUB_PROJECT_NAME}:bleeding
             docker push ${DOCKERHUB_PROJECT_USER}/${DOCKERHUB_PROJECT_NAME}:bleeding
 
+  publish-docs:
+    executor: netlify-cli-executor
+    steps:
+      - attach_workspace:
+          at: ~/
+      - run:
+          name: Extract docs from artifacts
+          command: cd ~/project/dist/docs && tar xzf *.tar.gz
+      - run:
+          name: Deploy docs to Netlify
+          command: netlify deploy --prod -d dist/docs/helm -s ${NETLIFY_SITE_ID}
+
 workflows:
   version: 2
   build-workflow:
@@ -268,5 +284,15 @@ workflows:
           filters:
             branches:
               only: master
+            tags:
+              ignore: /^v.*/
+      - publish-docs:
+          requires:
+            - build-docs
+          filters:
+            branches:
+              only: 
+                - master
+                - jira/HELM-216
             tags:
               ignore: /^v.*/

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -14,6 +14,10 @@ executors:
     docker:
       - image: docker:19.03.0-git
 
+  docs-executor:
+    docker:
+      - image: opennms/asciibinder
+
 commands:
   docker-registry-login:
     description: "Connect to Docker Registry"
@@ -75,6 +79,15 @@ jobs:
           paths:
             - project
 
+  build-docs:
+    executor: docs-executor
+    steps:
+      - attach_workspace:
+          at: ~/
+      - run:
+          name: Generate documentation as static HTML
+          command: asciibinder package -l debug docs
+      
   make-tarball:
     executor: build-executor
     steps:
@@ -206,6 +219,12 @@ workflows:
             tags:
               only: /^v.*/
       - build:
+          requires:
+            - pre-build
+          filters:
+            tags:
+              only: /^v.*/
+      - build-docs:
           requires:
             - pre-build
           filters:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -32,9 +32,12 @@ commands:
             docker login -u ${DOCKERHUB_LOGIN} -p ${DOCKERHUB_PASS}
 jobs:
   pre-build:
-    executor: build-executor
+    executor: node-executor
     steps:
       - checkout
+      - run:
+          name: Get version number
+          command: ./get-version.sh
       - persist_to_workspace:
           root: ~/
           paths:
@@ -44,9 +47,6 @@ jobs:
     steps:
       - attach_workspace:
           at: ~/
-      - run:
-          name: Get version number
-          command: ./get-version.sh
       - restore_cache:
           name: Restore Package Cache
           keys:

--- a/docs/_distro_map.yml
+++ b/docs/_distro_map.yml
@@ -9,6 +9,3 @@ helm:
     master:
       name: Latest
       dir: latest
-    jira/HELM-216:
-      name: jira/helm-216
-      dir: latest

--- a/docs/_distro_map.yml
+++ b/docs/_distro_map.yml
@@ -9,3 +9,6 @@ helm:
     master:
       name: Latest
       dir: latest
+    jira/HELM-216:
+      name: jira/helm-216
+      dir: helm-216

--- a/docs/_distro_map.yml
+++ b/docs/_distro_map.yml
@@ -1,14 +1,14 @@
 ---
 helm:
   name: Helm
-  author: OpenNMS Docs Team <opennms-docs@lists.sourceforge.net>
+  author: OpenNMS Community <https://opennms.discourse.group>
   site: helm
   site_name: Helm
-  site_url: https://docs.opennms.org/helm
+  site_url: https://opennms-helm-doc.netlify.com
   branches:
     master:
       name: Latest
       dir: latest
     jira/HELM-216:
       name: jira/helm-216
-      dir: helm-216
+      dir: latest

--- a/docs/_stylesheets/helm.css
+++ b/docs/_stylesheets/helm.css
@@ -1,4 +1,4 @@
-@import url(http://maxcdn.bootstrapcdn.com/font-awesome/4.1.0/css/font-awesome.min.css);
+@import url(https://maxcdn.bootstrapcdn.com/font-awesome/4.1.0/css/font-awesome.min.css);
 /* ------------------------------------------------------------
 Image: "Spin" https://www.flickr.com/photos/eflon/3655695161/
 Author: eflon https://www.flickr.com/photos/eflon/


### PR DESCRIPTION
# Pull Request Check Sheet

* [x] Have you read and followed our [Contribution Guidelines](https://github.com/OpenNMS/opennms/blob/develop/CONTRIBUTING.md)?
* [x] Have you [made an issue in the OpenNMS issue tracker](https://issues.opennms.org)?<br>If so, you should:
  1. update the title of this PR to be of the format: `${JIRA-ISSUE-NUMBER}: subject of pull request`
  2. update the JIRA link at the bottom of this comment to refer to the real issue number
  3. prefix your commit messages with the issue number, if possible
* [x] Have you made a comment in that issue which points back to this PR?
* [x] Have you updated the JIRA link at the bottom of this comment to link to your issue?
* [ ] If this is a new feature, is there documentation?
* [ ] If this is a new feature or substantial change, are there tests that cover it?

## Overview

With this change, we add build steps to our CI/CD pipeline to build the documentation with CircleCI and publish it to netlify. The HELM docs are published to https://opennms-helm-doc.netlify.com.

## Reviewer hints

The publishing job trigger is filtered when we push to the master branch and when version number tags are pushed. To test the pipeline, I had to add the jira/helm-216 branch additionally to master to test if the pipeline works. We have to remove the a) branch filter in CircleCI and b) remove the branch in the distro file for Asciibinder before merging this PR. Follow up steps are described in https://issues.opennms.org/browse/HELM-221.

# External References

* JIRA (Issue Tracker): http://issues.opennms.org/browse/HELM-216
