### PR TITLE
HELM-214/HELM-222: Publish build artifacts with CircleCI to Cloudsmith

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -26,6 +26,9 @@ executors:
     docker:
       - image: opennms/netlify-cli:2.8.3-b1
 
+orbs:
+  cloudsmith: cloudsmith/cloudsmith@1.0.3
+
 commands:
   docker-registry-login:
     description: "Connect to Docker Registry"
@@ -273,6 +276,32 @@ jobs:
           name: Deploy docs to Netlify
           command: netlify deploy --prod -d dist/docs/helm -s ${NETLIFY_SITE_ID}
 
+  publish-rpm:
+    executor: cloudsmith/default
+    steps:
+      - attach_workspace:
+          at: ~/
+      - cloudsmith/ensure-api-key
+      - cloudsmith/install-cli
+      - cloudsmith/publish:
+          cloudsmith-repository: opennms/common
+          package-format: rpm
+          package-distribution: any-distro/any-version
+          package-path: dist/packages/*.rpm
+
+  publish-deb:
+    executor: cloudsmith/default
+    steps:
+      - attach_workspace:
+          at: ~/
+      - cloudsmith/ensure-api-key
+      - cloudsmith/install-cli
+      - cloudsmith/publish:
+          cloudsmith-repository: opennms/common
+          package-format: deb
+          package-distribution: any-distro/any-version
+          package-path: dist/packages/*.deb
+
 workflows:
   version: 2
   build-workflow:
@@ -340,5 +369,25 @@ workflows:
             branches:
               only: 
                 - master
+            tags:
+              ignore: /^v.*/
+      - publish-deb:
+          requires:
+            - make-deb
+          filters:
+            branches:
+              only: 
+                - master
+                - jira/HELM-214
+            tags:
+              ignore: /^v.*/
+      - publish-rpm:
+          requires:
+            - make-rpm
+          filters:
+            branches:
+              only: 
+                - master
+                - jira/HELM-214
             tags:
               ignore: /^v.*/

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -153,7 +153,7 @@ jobs:
       - run:
           name: Create RPM package
           command: |
-            ./makerpm.js
+            ./makerpm.js --release "$(git log --pretty=format:%cd --date=short -1 | sed -e s,-,,g).${CIRCLE_BUILD_NUM}"
       - store_artifacts:
           path: ./dist/packages
       - persist_to_workspace:
@@ -169,7 +169,7 @@ jobs:
       - run:
           name: Create DEB package
           command: |
-            ./makedeb.js
+            ./makedeb.js --release "$(git log --pretty=format:%cd --date=short -1 | sed -e s,-,,g).${CIRCLE_BUILD_NUM}"
       - store_artifacts:
           path: ./dist/packages
       - persist_to_workspace:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -141,7 +141,7 @@ jobs:
           root: ~/
           paths:
             - ./project/helm-docker-image
-  make-rpm-package:
+  make-rpm:
     executor: build-executor
     steps:
       - attach_workspace:
@@ -150,6 +150,22 @@ jobs:
           name: Create RPM package
           command: |
             ./makerpm.js
+      - store_artifacts:
+          path: ./dist/packages
+      - persist_to_workspace:
+          root: ~/
+          paths:
+            - ./project/dist/packages
+
+  make-deb:
+    executor: build-executor
+    steps:
+      - attach_workspace:
+          at: ~/
+      - run:
+          name: Create DEB package
+          command: |
+            ./makedeb.js
       - store_artifacts:
           path: ./dist/packages
       - persist_to_workspace:
@@ -285,7 +301,13 @@ workflows:
           filters:
             tags:
               only: /^v.*/
-      - make-rpm-package:
+      - make-rpm:
+          requires:
+            - build
+          filters:
+            tags:
+              only: /^v.*/
+      - make-deb:
           requires:
             - build
           filters:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,9 +2,13 @@ version: 2.1
 
 executors:
 
-  build-executor:
+  build-executor-centos:
     docker:
       - image: opennmsbamboo/node-centos
+
+  build-executor-debian:
+    docker:
+      - image: opennmsbamboo/node-debian
 
   node-executor:
     docker:
@@ -105,7 +109,7 @@ jobs:
             - ./project/dist/docs
 
   make-tarball:
-    executor: build-executor
+    executor: build-executor-centos
     steps:
       - attach_workspace:
           at: ~/
@@ -142,7 +146,7 @@ jobs:
           paths:
             - ./project/helm-docker-image
   make-rpm:
-    executor: build-executor
+    executor: build-executor-centos
     steps:
       - attach_workspace:
           at: ~/
@@ -158,7 +162,7 @@ jobs:
             - ./project/dist/packages
 
   make-deb:
-    executor: build-executor
+    executor: build-executor-debian
     steps:
       - attach_workspace:
           at: ~/

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -378,7 +378,6 @@ workflows:
             branches:
               only: 
                 - master
-                - jira/HELM-214
             tags:
               ignore: /^v.*/
       - publish-rpm:
@@ -388,6 +387,5 @@ workflows:
             branches:
               only: 
                 - master
-                - jira/HELM-214
             tags:
               ignore: /^v.*/

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -141,6 +141,15 @@ jobs:
           root: ~/
           paths:
             - ./project/helm-docker-image
+  make-rpm-package:
+    executor: build-executor
+    steps:
+      - attach_workspace:
+          at: ~/
+      - run:
+          name: Create RPM package
+          command: |
+            ./makerpm.js
 
   publish-docker-image-latest:
     executor: docker-executor
@@ -267,6 +276,12 @@ workflows:
       - make-docker-image:
           requires:
             - make-tarball
+          filters:
+            tags:
+              only: /^v.*/
+      - make-rpm-package:
+          requires:
+            - build
           filters:
             tags:
               only: /^v.*/

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -150,6 +150,12 @@ jobs:
           name: Create RPM package
           command: |
             ./makerpm.js
+      - store_artifacts:
+          path: ./dist/packages
+      - persist_to_workspace:
+          root: ~/
+          paths:
+            - ./project/dist/packages
 
   publish-docker-image-latest:
     executor: docker-executor

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -388,7 +388,7 @@ workflows:
           filters:
             branches:
               only: 
-                - master
+                - develop
             tags:
               ignore: /^v.*/
       - publish-rpm:
@@ -397,6 +397,6 @@ workflows:
           filters:
             branches:
               only: 
-                - master
+                - develop
             tags:
               ignore: /^v.*/

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,11 +4,11 @@ executors:
 
   build-executor-centos:
     docker:
-      - image: opennmsbamboo/node-centos
+      - image: opennms/build-env:11.0.5.10-3.6.3-b3976
 
   build-executor-debian:
     docker:
-      - image: opennmsbamboo/node-debian
+      - image: opennms/build-env:debian-jdk11-b3982
 
   node-executor:
     docker:
@@ -28,6 +28,7 @@ executors:
 
 orbs:
   cloudsmith: cloudsmith/cloudsmith@1.0.3
+  sign-packages: opennms/sign-packages@0.0.8
 
 commands:
   docker-registry-login:
@@ -157,6 +158,11 @@ jobs:
           name: Create RPM package
           command: |
             ./makerpm.js --release "$(git log --pretty=format:%cd --date=short -1 | sed -e s,-,,g).${CIRCLE_BUILD_NUM}"
+      - sign-packages/install-rpm-dependencies
+      - sign-packages/setup-env
+      - sign-packages/sign-rpms:
+          gpgname: opennms@opennms.org
+          packages: dist/packages/*.rpm
       - store_artifacts:
           path: ./dist/packages
       - persist_to_workspace:
@@ -173,6 +179,11 @@ jobs:
           name: Create DEB package
           command: |
             ./makedeb.js --release "$(git log --pretty=format:%cd --date=short -1 | sed -e s,-,,g).${CIRCLE_BUILD_NUM}"
+      - sign-packages/install-deb-dependencies
+      - sign-packages/setup-env
+      - sign-packages/sign-debs:
+          gpgname: opennms@opennms.org
+          packages: dist/packages/*.deb
       - store_artifacts:
           path: ./dist/packages
       - persist_to_workspace:


### PR DESCRIPTION
# Pull Request Check Sheet

* [x] Have you read and followed our [Contribution Guidelines](https://github.com/OpenNMS/opennms/blob/develop/CONTRIBUTING.md)?
* [x] Have you [made an issue in the OpenNMS issue tracker](https://issues.opennms.org)?<br>If so, you should:
  1. update the title of this PR to be of the format: `${JIRA-ISSUE-NUMBER}: subject of pull request`
  2. update the JIRA link at the bottom of this comment to refer to the real issue number
  3. prefix your commit messages with the issue number, if possible
* [x] Have you made a comment in that issue which points back to this PR?
* [x] Have you updated the JIRA link at the bottom of this comment to link to your issue?
* [ ] If this is a new feature, is there documentation?
* [ ] If this is a new feature or substantial change, are there tests that cover it?

Created two build jobs to build DEB and RPM packages. Added the Cloudsmith orb to publish it to our [repository](https://cloudsmith.io/~opennms/repos/common/packages/). The Cloudsmith ORB requires the CLOUDSMITH_API_KEY environment variable to be set on the project.

## Reviewer hint

We create RPM and DEB packages in the `dist/packages` directory. In the `make-deb` and `make-rpm`, I've just set to store everything in the dist/packages dir see:

```yaml
      - store_artifacts:
          path: ./dist/packages
```
There is no wildcard support in the store_artifacts directive and I didn't want to mess around the makerpm and makedeb scripts.

# External References

* JIRA (Issue Tracker): https://issues.opennms.org/browse/HELM-214
* JIRA (Issue Tracker): https://issues.opennms.org/browse/HELM-222