### PR TITLE
HELM-247: fix alarm table and filter on Grafana 7

### DIFF
--- a/src/lib/filter_column.js
+++ b/src/lib/filter_column.js
@@ -1,3 +1,6 @@
+import { TextBoxVariable } from './text_box_variable';
+import { QueryVariable } from './query_variable';
+
 const randomString = () => {
   const chars = '0123456789ABCDEFGHIJKLMNOPQRSTUVWXTZabcdefghiklmnopqrstuvwxyz'.split('');
   const length = 20;
@@ -28,6 +31,31 @@ export class FilterColumn {
 
   set text(text) {
     this._text = text;
+  }
+
+  toModel($injector, filterState) {
+    const model = Object.assign({}, this);
+    model.type = this.inputType === 'text' ? 'textbox' : 'query';
+    model.multi = this.inputType === 'multi' || this.inputType === undefined;
+
+    console.debug('model=', model);
+    let ret = undefined;
+    if (model.type === 'textbox') {
+      ret = $injector.instantiate(TextBoxVariable, { model: model, filterColumn: this, filterState: filterState });
+    } else if (model.type === 'query') {
+      ret = $injector.instantiate(QueryVariable, { model: model, filterColumn: this, filterState: filterState });
+    }
+
+    /*
+    if (this.selected) {
+      ret.setValue(this.selected);
+      console.debug('toModel(): selected=', this.selected, this);
+    } else {
+      console.debug('toModel(): nothing selected', this);
+    }
+    */
+
+    return ret;
   }
 
   toJSON() {

--- a/src/lib/query_variable.js
+++ b/src/lib/query_variable.js
@@ -1,0 +1,255 @@
+import _ from 'lodash';
+import { assignModelProperties, containsVariable, setOptionAsCurrent, setOptionFromUrl, validateVariableSelectionState } from './utils';
+import { grafanaResource } from './grafana_resource';
+
+const stringToJsRegex = grafanaResource('stringToJsRegex');
+
+function getNoneOption() {
+  return { text: 'None', value: '', isNone: true, selected: false };
+}
+
+export class QueryVariable {
+  /** @ngInject */
+  constructor(model, filterColumn, filterState, $q, dashboardSrv, datasourceSrv, templateSrv, timeSrv) {
+    this.defaults = {
+      type: 'query',
+      name: '',
+      label: null,
+      hide: 0, // VariableHide.dontHide,
+      skipUrlSync: false,
+      datasource: null,
+      query: '',
+      regex: '',
+      sort: 0, // VariableSort.disabled,
+      refresh: 0, // VariableRefresh.never,
+      multi: false,
+      includeAll: false,
+      allValue: null,
+      options: [],
+      current: {}, // as VariableOption,
+      tags: [],
+      useTags: false,
+      tagsQuery: '',
+      tagValuesQuery: '',
+      definition: '',
+      index: -1,
+    };
+
+    this.$q = $q;
+    this.dashboardSrv = dashboardSrv;
+    this.datasourceSrv = datasourceSrv;
+    this.templateSrv = templateSrv;
+    this.timeSrv = timeSrv;
+    this.filterColumn = filterColumn;
+    this.filterState = filterState;
+
+    this.initialized = false;
+    this.inFlight = this.$q.when();
+
+    assignModelProperties(this, model, this.defaults);
+    this.updateOptionsFromMetricFindQuery.bind(this);
+  }
+
+  getSaveModel() {
+    // copy back model properties to model
+    assignModelProperties(this.model, this, this.defaults);
+
+    // remove options
+    if (this.refresh !== 0) {
+      this.model.options = [];
+    }
+
+    return this.model;
+  }
+
+  setValue(option) {
+    if (!option && !this.initialized) {
+      console.debug('QueryVariable.setValue(): not yet initialized', option);
+      return;
+    }
+    console.debug('QueryVariable.setValue()', option);
+    return setOptionAsCurrent(this, option);
+  }
+
+  setValueFromUrl(urlValue) {
+    return setOptionFromUrl(this, urlValue);
+  }
+
+  getValueForUrl() {
+    if (this.current.text === 'All') {
+      return 'All';
+    }
+    return this.current.value;
+  }
+
+  updateOptions(searchFilter) {
+    this.inFlight = this.inFlight.finally(() => {
+      console.debug('QueryVariable.updateOptions(' + searchFilter + ')', this);
+      return this.datasourceSrv
+        .get(this.datasource ? this.datasource : '')
+        .then((ds) => this.updateOptionsFromMetricFindQuery(ds, searchFilter))
+        .then(this.updateTags.bind(this))
+        .then(validateVariableSelectionState(this)).catch((err) => {
+          console.debug('QueryVariable.updateOptions(): err=', err);
+          return this.$q.reject(err);
+        });
+    });
+    this.inFlight.finally(() => {
+      console.debug('QueryVariable.updateOptions(): complete', this.options);
+      this.initialized = true;
+    });
+    return this.inFlight;
+  }
+
+  updateTags(datasource) {
+    console.debug('QueryVariable.updateTags()', datasource);
+    if (this.useTags) {
+      return this.metricFindQuery(datasource, this.tagsQuery).then((results) => {
+        this.tags = [];
+        for (let i = 0; i < results.length; i++) {
+          this.tags.push(results[i].text);
+        }
+        return datasource;
+      });
+    } else {
+      delete this.tags;
+    }
+
+    return datasource;
+  }
+
+  getValuesForTag(tagKey) {
+    return this.datasourceSrv.get(this.datasource ? this.datasource : '').then((datasource) => {
+      const query = this.tagValuesQuery.replace('$tag', tagKey);
+      return this.metricFindQuery(datasource, query).then((results) => {
+        return _.map(results, value => {
+          return value.text;
+        });
+      });
+    });
+  }
+
+  updateOptionsFromMetricFindQuery(datasource, searchFilter) {
+    console.debug('QueryVariable.updateOptionsFromMetricFindQuery()', datasource, searchFilter);
+    return this.metricFindQuery(datasource, this.query, searchFilter).then((results) => {
+      console.debug('QueryVariable.updateOptionsFromMetricFindQuery(): results=', results);
+      this.options = this.metricNamesToVariableValues(results);
+      if (this.includeAll) {
+        this.addAllOption();
+      }
+      console.debug('QueryVariable.updateOptionsFromMetricFindQuery() options=', this.options);
+      if (!this.options.length) {
+        this.options.push(getNoneOption());
+      }
+      return datasource;
+    }).catch((err) => {
+      console.debug('QueryVariable.updateOptionsFromMetricFindQuery(): err=', err);
+      return this.$q.reject(err);
+    });
+  }
+
+  metricFindQuery(datasource, query, searchFilter) {
+    console.debug('QueryVariable.metricFindQuery():', datasource, query, searchFilter);
+    const options = { range: undefined, variable: this, searchFilter: searchFilter };
+
+    if (this.refresh === 2) {
+      options.range = this.timeSrv.timeRange();
+    }
+
+    return datasource.metricFindQuery(query, options).catch((err) => {
+      console.debug('QueryVariable.metricFindQuery(): err=', err);
+      return this.$q.reject(err);
+    });
+  }
+
+  addAllOption() {
+    this.options.unshift({ text: 'All', value: '$__all', selected: false });
+  }
+
+  metricNamesToVariableValues(metricNames) {
+    let regex, options, i, matches;
+    options = [];
+
+    console.debug('QueryVariable.metricNamesToVariableValues()', metricNames);
+    if (this.regex) {
+      regex = stringToJsRegex(this.templateSrv.replace(this.regex, {}, 'regex'));
+    }
+    for (i = 0; i < metricNames.length; i++) {
+      const item = metricNames[i];
+      let text = item.text === undefined || item.text === null ? item.value : item.text;
+      if (item.label && text === undefined || text === null) {
+        text = item.label;
+      }
+
+      let value = item.value === undefined || item.value === null ? text : item.value;
+      if (item.id && (value === undefined || value === null)) {
+        value = item.id;
+      }
+
+      if (_.isNumber(value)) {
+        value = value.toString();
+      }
+
+      if (_.isNumber(text)) {
+        text = text.toString();
+      }
+
+      if (regex) {
+        matches = regex.exec(value);
+        if (!matches) {
+          continue;
+        }
+        if (matches.length > 1) {
+          value = matches[1];
+          text = matches[1];
+        }
+      }
+
+      const opt = { text: text, value: value };
+      console.debug('metric', item, opt);
+
+      options.push(opt);
+    }
+
+    options = _.uniqBy(options, 'value');
+    console.debug('QueryVariable.metricNamesToVariableValues(): options=', options);
+    return this.sortVariableValues(options, this.sort);
+  }
+
+  sortVariableValues(options, sortOrder) {
+    if (sortOrder === 0) {
+      return options;
+    }
+
+    const sortType = Math.ceil(sortOrder / 2);
+    const reverseSort = sortOrder % 2 === 0;
+
+    if (sortType === 1) {
+      options = _.sortBy(options, 'text');
+    } else if (sortType === 2) {
+      options = _.sortBy(options, opt => {
+        const matches = opt.text.match(/.*?(\d+).*/);
+        if (!matches || matches.length < 2) {
+          return -1;
+        } else {
+          return parseInt(matches[1], 10);
+        }
+      });
+    } else if (sortType === 3) {
+      options = _.sortBy(options, opt => {
+        return _.toLower(opt.text);
+      });
+    }
+
+    if (reverseSort) {
+      options = options.reverse();
+    }
+
+    return options;
+  }
+
+  dependsOn(variable) {
+    return containsVariable(this.query, this.datasource, this.regex, variable.name);
+  }
+
+}

--- a/src/lib/text_box_variable.js
+++ b/src/lib/text_box_variable.js
@@ -1,0 +1,54 @@
+import { assignModelProperties, setOptionAsCurrent, setOptionFromUrl } from './utils';
+
+export class TextBoxVariable {
+  /** @ngInject **/
+  constructor(model, filterColumn, filterState, $q, dashboardSrv, datasourceSrv, templateSrv) {
+    this.defaults = {
+      type: 'textbox',
+      name: '',
+      label: '',
+      hide: 0, // VariableHide.dontHide
+      query: '',
+      current: {}, // as VariableOption
+      options: [],
+      skipUrlSync: false,
+    }
+
+    this.$q = $q;
+    this.dashboardSrv = dashboardSrv;
+    this.datasourceSrv = datasourceSrv;
+    this.templateSrv = templateSrv;
+    this.filterColumn = filterColumn;
+    this.filterState = filterState;
+
+    assignModelProperties(this, model, this.defaults);
+  }
+
+  getSaveModel() {
+    assignModelProperties(this.model, this, this.defaults);
+    return this.model;
+  }
+
+  setValue(option) {
+    setOptionAsCurrent(this, option);
+  }
+
+  updateOptions() {
+    this.options = [{ text: this.query.trim(), value: this.query.trim(), selected: false }];
+    this.current = this.options[0];
+    return Promise.resolve();
+  }
+
+  dependsOn() {
+    return false;
+  }
+
+  setValueFromUrl(urlValue) {
+    this.query = urlValue;
+    return setOptionFromUrl(this, urlValue, this.$q);
+  }
+
+  getValueForUrl() {
+    return this.current.value;
+  }
+}

--- a/src/lib/utils.js
+++ b/src/lib/utils.js
@@ -1,0 +1,239 @@
+import _ from 'lodash';
+
+export function assignModelProperties(target, source, defaults) {
+  for (const key in defaults) {
+    if (!defaults.hasOwnProperty(key)) {
+      continue;
+    }
+
+    target[key] = source[key] === undefined ? defaults[key] : source[key];
+  }
+}
+
+export function selectOptionsForCurrentValue(variable) {
+  let i, y, value, option;
+  const selected = [];
+
+  for (i = 0; i < variable.options.length; i++) {
+    option = variable.options[i];
+    option.selected = false;
+    if (_.isArray(variable.current.value)) {
+      for (y = 0; y < variable.current.value.length; y++) {
+        value = variable.current.value[y];
+        if (option.value === value) {
+          option.selected = true;
+          selected.push(option);
+        }
+      }
+    } else if (option.value === variable.current.value) {
+      option.selected = true;
+      selected.push(option);
+    }
+  }
+
+  return selected;
+}
+
+export function setOptionAsCurrent(variable, option) {
+  variable.current = _.cloneDeep(option || {});
+
+  if (_.isArray(variable.current.text) && variable.current.text.length > 0) {
+    variable.current.text = variable.current.text.join(' + ');
+  } else if (_.isArray(variable.current.value) && variable.current.value[0] !== '$__all') {
+    variable.current.text = variable.current.value.join(' + ');
+  }
+
+  selectOptionsForCurrentValue(variable);
+  return variableUpdated(variable);
+}
+
+export function variableUpdated(variable, emitChangeEvents) {
+  const $q = variable.$q;
+  const dashboardSrv = variable.dashboardSrv;
+  const templateSrv = variable.templateSrv;
+
+  // if there is a variable lock ignore cascading update because we are in a boot up scenario
+  if (variable.initLock) {
+    return $q.when();
+  }
+
+  const getVariables = templateSrv.getVariables.bind(templateSrv) || dashboardSrv.dashboard.getVariables.bind(dashboardSrv.dashboard);
+  const variables = getVariables();
+  let promises = [];
+
+  // in theory we should create an efficient sub-list of variables to update, but for now just do them all YOLO
+  variables.forEach(v => promises.push(v.updateOptions()));
+  /*
+  const g = createGraph(getVariables());
+  const node = g.getNode(variable.name);
+  if (node) {
+    promises = node.getOptimizedInputEdges().map(e => {
+      const variable = getVariables().find(v => v.name === e.inputNode.name);
+      return variable.updateOptions();
+    });
+  }
+  */
+
+  templateSrv.setGlobalVariable(variable.id, variable.current);
+  //templateSrv.grafanaVariables[variable.id] = variable.current;
+
+  return $q.all(promises).then(() => {
+    if (emitChangeEvents) {
+      dashboardSrv.dashboard.templateVariableValueUpdated();
+      dashboardSrv.dashboard.startRefresh();
+    }
+  });
+}
+
+
+export function setOptionFromUrl(variable, urlValue, $q) {
+  let promise = $q.when();
+
+  if (variable.refresh) {
+    promise = variable.updateOptions();
+  }
+
+  return promise.then(() => {
+    // Simple case. Value in url matches existing options text or value.
+    let option = _.find(variable.options, op => {
+      return op.text === urlValue || op.value === urlValue;
+    });
+
+    // No luck either it is array or value does not exist in the variables options.
+    if (!option) {
+      let defaultText = urlValue;
+      const defaultValue = urlValue;
+
+      if (_.isArray(urlValue)) {
+        // Multiple values in the url. We construct text as a list of texts from all matched options.
+        defaultText = urlValue.reduce((acc, item) => {
+          const t = _.find(variable.options, { value: item });
+          if (t) {
+            acc.push(t.text);
+          } else {
+            acc.push(item);
+          }
+
+          return acc;
+        }, []);
+      }
+
+      // It is possible that we did not match the value to any existing option. In that case the url value will be
+      // used anyway for both text and value.
+      option = { text: defaultText, value: defaultValue };
+    }
+
+    if (variable.multi) {
+      // In case variable is multiple choice, we cast to array to preserve the same behaviour as when selecting
+      // the option directly, which will return even single value in an array.
+      option = { text: _.castArray(option.text), value: _.castArray(option.value) };
+    }
+
+    return variable.setValue(option);
+  });
+}
+
+export function validateVariableSelectionState(variable, defaultValue) {
+  if (!variable.current) {
+    variable.current = {};
+  }
+
+  if (_.isArray(variable.current.value)) {
+    let selected = selectOptionsForCurrentValue(variable);
+
+    // if none pick first
+    if (selected.length === 0) {
+      selected = variable.options[0];
+    } else {
+      selected = {
+        value: _.map(selected, val => {
+          return val.value;
+        }),
+        text: _.map(selected, val => {
+          return val.text;
+        }),
+      };
+    }
+
+    return variable.setValue(selected);
+  } else {
+    let option = undefined;
+
+    // 1. find the current value
+    option = _.find(variable.options, {
+      text: variable.current.text,
+    });
+    if (option) {
+      return variable.setValue(option);
+    }
+
+    // 2. find the default value
+    if (defaultValue) {
+      option = _.find(variable.options, {
+        text: defaultValue,
+      });
+      if (option) {
+        return variable.setValue(option);
+      }
+    }
+
+    // 3. use the first value
+    if (variable.options) {
+      return variable.setValue(variable.options[0]);
+    }
+
+    // 4... give up
+    return Promise.resolve();
+  }
+}
+
+export const variableRegex = /\$(\w+)|\[\[([\s\S]+?)(?::(\w+))?\]\]|\${(\w+)(?:\.([^:^}]+))?(?::(\w+))?}/g;
+
+export const variableRegexExec = (variableString) => {
+  variableRegex.lastIndex = 0;
+  return variableRegex.exec(variableString);
+};
+
+export function containsVariable(...args) {
+  const variableName = args[args.length - 1];
+  args[0] = _.isString(args[0]) ? args[0] : Object['values'](args[0]).join(' ');
+  const variableString = args.slice(0, -1).join(' ');
+  const matches = variableString.match(variableRegex);
+  const isMatchingVariable =
+    matches !== null
+      ? matches.find(match => {
+          const varMatch = variableRegexExec(match);
+          return varMatch !== null && varMatch.indexOf(variableName) > -1;
+        })
+      : false;
+
+  return !!isMatchingVariable;
+}
+
+/*
+export function setAdhocFilter(options) {
+  let variable = _.find(this.variables, {
+    type: 'adhoc',
+    datasource: options.datasource,
+  });
+  if (!variable) {
+    variable = this.createVariableFromModel({
+      name: 'Filters',
+      type: 'adhoc',
+      datasource: options.datasource,
+    });
+    this.addVariable(variable);
+  }
+
+  const filters = variable.filters;
+  let filter: any = _.find(filters, { key: options.key, value: options.value });
+
+  if (!filter) {
+    filter = { key: options.key, value: options.value };
+    filters.push(filter);
+  }
+
+  filter.operator = options.operator;
+  this.variableUpdated(variable, true);
+}
+*/

--- a/src/panels/filter-panel/editor.html
+++ b/src/panels/filter-panel/editor.html
@@ -8,27 +8,22 @@
         <div class="gf-form column-reorder filter-column" ng-repeat="column in editor.panel.columns" id="column-{{$index}}" draggable="true">
             <div class="gf-form-inline gf-form-label">
                 <i class="pointer fa fa-remove" ng-click="editor.removeColumn(column, $index)"></i>
-                <span class="onms-label width-16">{{column.text}} ({{column.entityType.label}})</span>
-                <div class="onms-radio-group">
-                    <span class="radio-item">
-                        <input type="radio" id="radio-{{$index}}-single" name="radio-{{$index}}" ng-model="column.inputType" class="gf-form-input" ng-value="'single'" ng-change="ctrl.variableChanged(column, $index)">
-                        <label for="radio-{{$index}}-single">Single</label>
-                    </span>
-                    <span class="radio-item">
-                        <input type="radio" id="radio-{{$index}}-multi" name="radio-{{$index}}" ng-model="column.inputType" class="gf-form-input" ng-value="'multi'" ng-change="ctrl.variableChanged(column, $index)">
-                        <label for="radio-{{$index}}-multi">Multi</label>
-                    </span>
-                    <span class="radio-item">
-                        <input type="radio" id="radio-{{$index}}-text" name="radio-{{$index}}" ng-model="column.inputType" class="gf-form-input" ng-value="'text'" ng-change="ctrl.variableChanged(column, $index)">
-                        <label for="radio-{{$index}}-text">Text</label>
-                    </span>
+                <span class="onms-label width-12">{{column.text}}</span>
+            </div>
+            <div class="gf-form-inline">
+                <div class="gf-form-select-wrapper">
+                    <select class="gf-form-input gf-size-auto"
+                        ng-model="column.inputType"
+                        ng-change="ctrl.variableChanged(column, $index)">
+                        <option value="single">Single</option>
+                        <option value="multi">Multi</option>
+                        <option value="text">Text</option>
+                    </select>
                 </div>
-                <div class="gf-form">
-                    <div class="gf-form-inline gf-form-label">
-                        <span class="gf-form-label gf-size-8">Custom Label:</span>
-                        <input type="text" id="label-{{$index}}" ng-model="column.label" class="gf-form-input" ng-change="ctrl.variableChanged(column, $index)">
-                    </div>
-                </div>
+            </div>
+            <div class="gf-form-inline">
+                <span class="gf-form-label gf-size-10">Label:</span>
+                <input type="text" id="label-{{$index}}" ng-model="column.label" class="gf-form-input" ng-change="ctrl.variableChanged(column, $index)">
             </div>
         </div>
         <div class="gf-form" id="alarm-filter-editor-add-column">

--- a/src/panels/filter-panel/editor.js
+++ b/src/panels/filter-panel/editor.js
@@ -157,7 +157,7 @@ export class FilterPanelEditorCtrl {
         if (this.srcIndex !== undefined && this.destIndex !== undefined) {
           this.$scope.$apply(() => {
             this.panel.columns.splice(this.destIndex, 0, this.panel.columns.splice(this.srcIndex, 1)[0]);
-            this.panelCtrl.render();
+            this.render();
           });
           console.log('dropped "' + this.panel.columns[this.srcIndex].text + '" onto "' + this.panel.columns[this.destIndex].text + '"');
         } else {
@@ -263,6 +263,7 @@ export class FilterPanelEditorCtrl {
   }
 
   render() {
+    this.panel.render();
     this.panelCtrl.render();
   }
 
@@ -327,6 +328,7 @@ export class FilterPanelEditorCtrl {
   removeColumn(column, index) {
     console.debug('removing column:', column);
     this.panel.columns.splice(index, 1);
+    this.render();
     return this.reset();
   }
 }

--- a/src/panels/filter-panel/module.html
+++ b/src/panels/filter-panel/module.html
@@ -3,7 +3,7 @@
         <div class="gf-form">
             <label class="gf-form-label template-variable">{{v.label || v.name}}</label>
             <onms-value-select-dropdown ng-if="v.inputType !== 'text'" class="max-width-15" dashboard="ctrl.dashboard" variable="v" on-updated="ctrl.variableUpdated(v, $index)"></onms-value-select-dropdown>
-            <input type="text" ng-if="v.inputType === 'text'" ng-model="v.query" ng-change="ctrl.variableUpdated(v, $index)" class="gf-form-input">
+            <input type="text" ng-if="v.inputType === 'text'" ng-model="v.query" ng-model-options="{ debounce: 250 }" ng-change="ctrl.variableUpdated(v, $index)" class="gf-form-input">
         </div>
     </div>
 </div>


### PR DESCRIPTION
This is incredibly gross, but I got it all working on Grafana 6 as well as Grafana 7 (I tested with 6.7.3, 7.1.0 and 7.2.0)

* port over variable-management code from Grafana 6.7
* disable ad-hoc queries in Grafana 7 (I _think_ we don't actually mark any columns as filterable anyway, so this should be a no-op, in theory)
* cleanups to the filter panel layout to fit Grafana 7's right-side tray format
* debounce input to text fields in the filter panel

# External References

* JIRA (Issue Tracker): http://issues.opennms.org/browse/HELM-247