### PR TITLE
do not initialize 'target' member of query controllers

### DIFF
--- a/src/datasources/entity-ds/query_ctrl.ts
+++ b/src/datasources/entity-ds/query_ctrl.ts
@@ -24,7 +24,7 @@ export class OpenNMSEntityDatasourceQueryCtrl extends QueryCtrl {
   featuredAttributes: boolean;
   filterMapping: any;
   panelCtrl: any;
-  target = {} as any;
+  target: any;
   uiFilter: any;
 
   /** @ngInject */

--- a/src/datasources/flow-ds/datasource.js
+++ b/src/datasources/flow-ds/datasource.js
@@ -190,7 +190,7 @@ export class FlowDatasource {
   // Used by template queries
   metricFindQuery(query) {
     if (query === null || query === undefined || query === "") {
-      return this.$q.resolve([]);
+      return this.q.resolve([]);
     }
     query = this.templateSrv.replace(query);
 
@@ -207,7 +207,7 @@ export class FlowDatasource {
       return this.metricFindInterfacesOnExporterNode(interfacesOnExporterNodeQuery[1]);
     }
 
-    return this.$q.resolve([]);
+    return this.q.resolve([]);
   }
 
   metricFindExporterNodes(/* query */) {

--- a/src/datasources/flow-ds/query_ctrl.ts
+++ b/src/datasources/flow-ds/query_ctrl.ts
@@ -17,7 +17,7 @@ export class FlowDatasourceQueryCtrl extends QueryCtrl {
   functions = [] as any[];
   panelCtrl: any;
   segments = [] as any[];
-  target = {} as any;
+  target: any;
 
   scope: any;
 

--- a/src/datasources/perf-ds/query_ctrl.ts
+++ b/src/datasources/perf-ds/query_ctrl.ts
@@ -15,7 +15,7 @@ export class OpenNMSQueryCtrl extends QueryCtrl {
   datasource: any;
   error: any;
   nodeResources = [] as any[] | undefined;
-  target = {} as any;
+  target: any;
   types: typeof QueryType;
 
   /** @ngInject */
@@ -33,6 +33,11 @@ export class OpenNMSQueryCtrl extends QueryCtrl {
     this.types = QueryType;
 
     this.error = this.validateTarget();
+
+    if (!this.target) {
+      this.target = {};
+    }
+
     /*
     this.$rootScope = $rootScope;
     this.$q = $q;


### PR DESCRIPTION
The `target` member is already set when the constructor is called. Do not overwrite its value by member initializers.