### PR TITLE
HELM-274: do not limit the number of properties

### DIFF
--- a/src/datasources/entity-ds/datasource.ts
+++ b/src/datasources/entity-ds/datasource.ts
@@ -349,7 +349,7 @@ export class OpenNMSEntityDatasource {
                           }
                       }));
               }
-              return property.findValues({limit: 1000}).then(values => {
+              return property.findValues({limit: 0}).then(values => {
                   return values.filter(value => value !== null).map(value => {
                       return {id: value, label: value, text: value ? String(value) : value, value: value}
                   });


### PR DESCRIPTION
Small change to not limit the number of search property results.  This _shouldn't_ be too bad since the search API doesn't send a large payload per entry.

# External References

* JIRA (Issue Tracker): http://issues.opennms.org/browse/HELM-274
* Continuous Integration: [CircleCI](https://circleci.com/gh/OpenNMS/opennms-helm)
