### PR TITLE
HELM-228: implement entities for IP/SNMP interfaces, services, and outages

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16590,9 +16590,9 @@
       }
     },
     "opennms": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/opennms/-/opennms-2.2.0.tgz",
-      "integrity": "sha512-8SnnDTJaOVK4+A9Qg4drCDtgPAS+4ZNQdxiHruoaLOTxlnKOr625UwpkbzRKzKR5CmpfFtCeNqPBhyr9XczQtg==",
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/opennms/-/opennms-2.3.0.tgz",
+      "integrity": "sha512-dDJXNIzB0Um3/skH81LSbRbTMl6gfKDJr+mYVenYI4zeeEbfxBgwybUULo34TUS4esOvJrkZfW+v5NyX15LvMA==",
       "requires": {
         "@antora/cli": "^2.3.4",
         "@antora/site-generator-default": "^2.3.4",
@@ -16611,7 +16611,7 @@
         "table": "^6.0.0",
         "version_compare": "^0.0.3",
         "x2js": "^3.4.1",
-        "xmldom": "github:xmldom/xmldom#0.7.0"
+        "xmldom": "github:xmldom/xmldom#0.7.2"
       },
       "dependencies": {
         "ansi-styles": {
@@ -23784,12 +23784,12 @@
       "resolved": "https://registry.npmjs.org/x2js/-/x2js-3.4.1.tgz",
       "integrity": "sha512-RCMEmHNsyeyzF5NyGHbmCCZU9N8uMiz9FluAj3CpfVREHpgm3JB9Wr/dEWdPqGHmK3lRd2fm0ccOWtuJ2YUowQ==",
       "requires": {
-        "xmldom": "github:xmldom/xmldom#0.7.0"
+        "xmldom": "github:xmldom/xmldom#0.7.2"
       },
       "dependencies": {
         "xmldom": {
-          "version": "github:xmldom/xmldom#c568938641cc1f121cef5b4df80fcfda1e489b6e",
-          "from": "github:xmldom/xmldom#0.7.0"
+          "version": "github:xmldom/xmldom#05736c315e4ef2e8a90b9b912ffbf7ef0e810a93",
+          "from": "github:xmldom/xmldom#0.7.2"
         }
       }
     },
@@ -23841,8 +23841,8 @@
       "dev": true
     },
     "xmldom": {
-      "version": "github:xmldom/xmldom#c568938641cc1f121cef5b4df80fcfda1e489b6e",
-      "from": "github:xmldom/xmldom#0.7.0"
+      "version": "github:xmldom/xmldom#05736c315e4ef2e8a90b9b912ffbf7ef0e810a93",
+      "from": "github:xmldom/xmldom#0.7.2"
     },
     "xmlhttprequest": {
       "version": "1.8.0",

--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "flot": "^0.8.3",
     "flot-axislabels": "https://github.com/j-white/flot-axislabels#master",
     "lodash": "^4.17.21",
-    "opennms": "^2.2.0",
+    "opennms": "^2.3.0",
     "parenthesis": "^3.1.7",
     "perfect-scrollbar": "^1.5.2",
     "q": "^1.5.1",

--- a/src/datasources/entity-ds/IpInterfaceEntity.ts
+++ b/src/datasources/entity-ds/IpInterfaceEntity.ts
@@ -1,0 +1,107 @@
+import { OnmsIpInterface } from 'opennms/src/model/OnmsIpInterface';
+
+import Entity from './Entity';
+import { AttributeMapping } from './mapping/AttributeMapping';
+
+const columns = [
+  { text: 'ID', resource: 'id' },
+  { text: 'IP Address', resource: 'ipAddress', featured: true, },
+  { text: 'Hostname', resource: 'hostname', featured: true, },
+  { text: 'Is Down?', resource: 'isDown', },
+  { text: 'Is Managed?', resource: 'isManaged', },
+  { text: 'Last Capsd Poll', resource: 'lastCapsdPoll', },
+  { text: 'Last Ingress Flow', resource: 'lastIngressFlow', },
+  { text: 'Last Egress Flow', resource: 'lastEgressFlow', },
+  { text: 'Service Count', resource: 'monitoredServiceCount', },
+  { text: 'SNMP Primary', resource: 'snmpPrimary', featured: true, },
+  { text: 'SNMP ifAlias', resource: 'snmpInterface.ifAlias' },
+  { text: 'SNMP ifDescr', resource: 'snmpInterface.ifDescr' },
+  { text: 'SNMP ifIndex', resource: 'snmpInterface.ifIndex' },
+  { text: 'SNMP PhysAddr', resource: 'snmpInterface.physAddr' },
+  { text: 'Data Source' }
+];
+
+const mapping = new AttributeMapping({
+  ifAlias: 'snmpInterface.ifAlias',
+  ifDescr: 'snmpInterface.ifDescr',
+  ifIndex: 'snmpInterface.ifIndex',
+  ifName: 'snmpInterface.ifName',
+  physAddr: 'snmpInterface.physAddr',
+});
+
+export default class IpInterfaceEntity extends Entity {
+  name = 'ipInterfaces';
+  type = 'ipInterface';
+
+  constructor(client, datasource) {
+    super(client, datasource);
+  }
+
+  getAttributeMapping() {
+    return mapping;
+  }
+
+  getColumns() {
+    return columns;
+  }
+
+  getProperties() {
+    return this.client.getIpInterfaceProperties();
+  }
+
+  getPropertyComparators(attribute) {
+    return this.client.getIpInterfacePropertyComparators(attribute);
+  }
+
+  findProperty(attribute) {
+    return this.client.findIpInterfaceProperty(attribute);
+  }
+
+  async query(filter) {
+    const ifaces = await this.client.findIpInterfaces(filter);
+
+    const rows = ifaces.map((iface: OnmsIpInterface) => {
+      return [
+        iface.id,
+        iface.ipAddress?.correctForm(),
+        iface.hostname,
+        iface.isDown,
+        iface.isManaged?.toDisplayString(),
+        iface.lastCapsdPoll,
+        iface.lastIngressFlow,
+        iface.lastEgressFlow,
+        iface.monitoredServiceCount,
+        iface.snmpPrimary?.toDisplayString(),
+        iface.snmpInterface?.ifAlias,
+        iface.snmpInterface?.ifDescr,
+        iface.snmpInterface?.ifIndex,
+        iface.snmpInterface?.physAddr?.toString(),
+        this.name,
+      ];
+    });
+
+    const metas = ifaces.map((iface) => {
+      return {
+        // Store the interface for easy access by the panels
+        [this.type]: iface,
+        // Store the entity type
+        'type': this.type,
+        // Store the name of the data-source as part of the data so that
+        // the panel can grab an instance of the DS to perform actions
+        // on the nodes, if necessary
+        'source': this.datasource.name,
+      }
+    });
+
+    return [
+      {
+        'columns': columns,
+        'meta': {
+          entity_metadata: metas,
+        },
+        'rows': rows,
+        'type': 'table',
+      }
+    ];
+  }
+}

--- a/src/datasources/entity-ds/MonitoredServiceEntity.ts
+++ b/src/datasources/entity-ds/MonitoredServiceEntity.ts
@@ -1,0 +1,103 @@
+import { OnmsMonitoredService } from 'opennms/src/model/OnmsMonitoredService';
+
+import Entity from './Entity';
+import { AttributeMapping } from './mapping/AttributeMapping';
+
+const columns = [
+  { text: 'ID', resource: 'id' },
+  { text: 'Last Failed Poll', resource: 'lastFail' },
+  { text: 'Last Good Poll', resource: 'lastGood' },
+  { text: 'IP Address', resource: 'ipInterface.ipAddress', featured: true },
+  { text: 'Type', resource: 'type.name', featured: true },
+  { text: 'Status', resource: 'status.id', featured: true },
+  { text: 'Data Source' }
+];
+
+const mapping = new AttributeMapping({
+  node: 'node.id',
+  nodeLabel: 'node.label',
+  foreignSource: 'node.foreignSource',
+  foreignId: 'node.foreignId',
+  ipAddress: 'ipInterface.ipAddress',
+});
+
+export default class MonitoredServiceEntity extends Entity {
+  name = 'monitoredServices';
+  type = 'monitoredService';
+
+  constructor(client, datasource) {
+    super(client, datasource);
+  }
+
+  getAttributeMapping() {
+    return mapping;
+  }
+
+  getColumns() {
+    return columns;
+  }
+
+  getProperties() {
+    return this.client.getMonitoredServiceProperties();
+  }
+
+  getPropertyComparators(attribute) {
+    return this.client.getMonitoredServicePropertyComparators(attribute);
+  }
+
+  findProperty(attribute) {
+    return this.client.findMonitoredServiceProperty(attribute);
+  }
+
+  async query(filter) {
+    const services = await this.client.findMonitoredServices(filter);
+    console.debug('services=', services);
+
+    const rows = services.map((service: OnmsMonitoredService) => {
+      console.debug('service=', service);
+
+      /*
+        { text: 'ID', resource: 'id' },
+  { text: 'Last Failed Poll', resource: 'lastFail' },
+  { text: 'Last Good Poll', resource: 'lastGood' },
+  { text: 'IP Address', resource: 'ipInterface.ipAddress', featured: true },
+  { text: 'Type', resource: 'type.name', featured: true },
+  { text: 'Status', resource: 'status.id', featured: true },
+  { text: 'Data Source' }
+*/
+      return [
+        service.id,
+        service.lastFail,
+        service.lastGood,
+        service.ipInterface?.ipAddress?.correctForm(),
+        service.type?.name,
+        service.status?.toDisplayString(),
+        this.name,
+      ];
+    });
+
+    const metas = services.map((iface) => {
+      return {
+        // Store the service for easy access by the panels
+        [this.type]: iface,
+        // Store the entity type
+        'type': this.type,
+        // Store the name of the data-source as part of the data so that
+        // the panel can grab an instance of the DS to perform actions
+        // on the nodes, if necessary
+        'source': this.datasource.name,
+      }
+    });
+
+    return [
+      {
+        'columns': columns,
+        'meta': {
+          entity_metadata: metas,
+        },
+        'rows': rows,
+        'type': 'table',
+      }
+    ];
+  }
+}

--- a/src/datasources/entity-ds/OutageEntity.ts
+++ b/src/datasources/entity-ds/OutageEntity.ts
@@ -1,0 +1,102 @@
+import { OnmsOutage } from 'opennms/src/model/OnmsOutage';
+
+import Entity from './Entity';
+import { AttributeMapping } from './mapping/AttributeMapping';
+
+const columns = [
+  { text: 'ID', resource: 'id' },
+  { text: 'Foreign Source', resource: 'foreignSource', featured: true },
+  { text: 'Foreign ID', resource: 'foreignId' },
+  { text: 'Node ID', resource: 'nodeId' },
+  { text: 'Node Label', resource: 'nodeLabel', featured: true },
+  { text: 'IP Address', resource: 'ipAddress', featured: true },
+  { text: 'Service', resource: 'monitoredService.type.name', featured: true },
+  { text: 'Lost Service', resource: 'ifLostService', featured: true },
+  { text: 'Regained Service', resource: 'ifRegainedService', featured: true },
+  { text: 'Suppressed', resource: 'suppressTime' },
+  { text: 'Suppressed By', resource: 'suppressedBy' },
+  { text: 'Perspective', resource: 'perspective', featured: true },
+  { text: 'Data Source' }
+];
+
+const mapping = new AttributeMapping({
+  rode: 'nodeId',
+});
+
+export default class OutageEntity extends Entity {
+  name = 'outages';
+  type = 'outage';
+
+  constructor(client, datasource) {
+    super(client, datasource);
+  }
+
+  getAttributeMapping() {
+    return mapping;
+  }
+
+  getColumns() {
+    return columns;
+  }
+
+  getProperties() {
+    return this.client.getOutageProperties();
+  }
+
+  getPropertyComparators(attribute) {
+    return this.client.getOutagePropertyComparators(attribute);
+  }
+
+  findProperty(attribute) {
+    return this.client.findOutageProperty(attribute);
+  }
+
+  async query(filter) {
+    const outages = await this.client.findOutages(filter);
+    console.debug('outages=', outages);
+
+    const rows = outages.map((outage: OnmsOutage) => {
+      console.debug('outage=', outage);
+
+      return [
+        outage.id,
+        outage.foreignSource,
+        outage.foreignId,
+        outage.nodeId,
+        outage.nodeLabel,
+        outage.ipAddress?.correctForm(),
+        outage.monitoredService?.type?.name,
+        outage.ifLostService,
+        outage.ifRegainedService,
+        outage.suppressTime,
+        outage.suppressedBy,
+        outage.perspective,
+        this.name,
+      ];
+    });
+
+    const metas = outages.map((iface) => {
+      return {
+        // Store the outage for easy access by the panels
+        [this.type]: iface,
+        // Store the entity type
+        'type': this.type,
+        // Store the name of the data-source as part of the data so that
+        // the panel can grab an instance of the DS to perform actions
+        // on the nodes, if necessary
+        'source': this.datasource.name,
+      }
+    });
+
+    return [
+      {
+        'columns': columns,
+        'meta': {
+          entity_metadata: metas,
+        },
+        'rows': rows,
+        'type': 'table',
+      }
+    ];
+  }
+}

--- a/src/datasources/entity-ds/SnmpInterfaceEntity.ts
+++ b/src/datasources/entity-ds/SnmpInterfaceEntity.ts
@@ -1,0 +1,102 @@
+import { OnmsSnmpInterface } from 'opennms/src/model/OnmsSnmpInterface';
+
+import Entity from './Entity';
+import { AttributeMapping } from './mapping/AttributeMapping';
+
+const columns = [
+  { text: 'ID', resource: 'id' },
+  { text: 'Index', resource: 'ifIndex' },
+  { text: 'Description', resource: 'ifDescr', featured: true },
+  { text: 'Type', resource: 'ifType' },
+  { text: 'Name', resource: 'ifName', featured: true },
+  { text: 'Speed', resource: 'ifSpeed', featured: true },
+  { text: 'Admin Status', resource: 'ifAdminStatus' },
+  { text: 'Operational Status', resource: 'ifOperStatus' },
+  { text: 'Alias', resource: 'ifAlias', featured: true },
+  { text: 'Last Capsd Poll', resource: 'lastCapsdPoll' },
+  { text: 'Collected?', resource: 'collect' },
+  { text: 'Polled?', resource: 'poll' },
+  { text: 'Last SNMP Poll', resource: 'lastSnmpPoll' },
+  { text: 'Physical Address', resource: 'physAddr' },
+  { text: 'Data Source' }
+];
+
+const mapping = new AttributeMapping({
+});
+
+export default class SnmpInterfaceEntity extends Entity {
+  name = 'snmpInterfaces';
+  type = 'snmpInterface';
+
+  constructor(client, datasource) {
+    super(client, datasource);
+  }
+
+  getAttributeMapping() {
+    return mapping;
+  }
+
+  getColumns() {
+    return columns;
+  }
+
+  getProperties() {
+    return this.client.getSnmpInterfaceProperties();
+  }
+
+  getPropertyComparators(attribute) {
+    return this.client.getSnmpInterfacePropertyComparators(attribute);
+  }
+
+  findProperty(attribute) {
+    return this.client.findSnmpInterfaceProperty(attribute);
+  }
+
+  async query(filter) {
+    const ifaces = await this.client.findSnmpInterfaces(filter);
+
+    const rows = ifaces.map((iface: OnmsSnmpInterface) => {
+      return [
+        iface.id,
+        iface.ifIndex,
+        iface.ifDescr,
+        iface.ifType,
+        iface.ifName,
+        iface.ifSpeed,
+        iface.ifAdminStatus?.toDisplayString(),
+        iface.ifOperStatus?.toDisplayString(),
+        iface.ifAlias,
+        iface.lastCapsdPoll,
+        iface.collect?.toDisplayString(),
+        iface.poll,
+        iface.lastSnmpPoll,
+        iface.physAddr?.toString(),
+        this.name,
+      ];
+    });
+
+    const metas = ifaces.map((iface) => {
+      return {
+        // Store the interface for easy access by the panels
+        [this.type]: iface,
+        // Store the entity type
+        'type': this.type,
+        // Store the name of the data-source as part of the data so that
+        // the panel can grab an instance of the DS to perform actions
+        // on the nodes, if necessary
+        'source': this.datasource.name,
+      }
+    });
+
+    return [
+      {
+        'columns': columns,
+        'meta': {
+          entity_metadata: metas,
+        },
+        'rows': rows,
+        'type': 'table',
+      }
+    ];
+  }
+}

--- a/src/datasources/entity-ds/datasource.ts
+++ b/src/datasources/entity-ds/datasource.ts
@@ -1,10 +1,16 @@
+import angular from 'angular';
+import _ from 'lodash';
+import {API, Model} from 'opennms';
+
 import {ClientDelegate} from '../../lib/client_delegate';
 import {FunctionFormatter} from '../../lib/function_formatter';
-import {API, Model} from 'opennms';
-import _ from 'lodash';
+
 import AlarmEntity from './AlarmEntity';
+import IpInterfaceEntity from './IpInterfaceEntity';
+import MonitoredServiceEntity from './MonitoredServiceEntity';
 import NodeEntity from './NodeEntity';
-import angular from 'angular';
+import OutageEntity from './OutageEntity';
+import SnmpInterfaceEntity from './SnmpInterfaceEntity';
 
 const isNumber = function isNumber(num) {
     return ((parseInt(num,10) + '') === (num + ''));
@@ -21,6 +27,26 @@ export const entityTypes = [
         label: 'Nodes',
         queryFunction: 'nodes',
     },
+    {
+        id: 'ipInterface',
+        label: 'IP Interfaces',
+        queryFunction: 'ipInterfaces',
+    },
+    {
+        id: 'snmpInterface',
+        label: 'SNMP Interfaces',
+        queryFunction: 'snmpInterfaces',
+    },
+    {
+        id: 'monitoredService',
+        label: 'Monitored Services',
+        queryFunction: 'monitoredServices',
+    },
+    {
+        id: 'outage',
+        label: 'Outages',
+        queryFunction: 'outages',
+    },
 ];
 
 export const getEntity = (e, client, datasource) => {
@@ -31,7 +57,11 @@ export const getEntity = (e, client, datasource) => {
     const entityType = e.id ? e.id : e;
     switch(entityType) {
         case 'alarm': return new AlarmEntity(client, datasource);
+        case 'ipInterface': return new IpInterfaceEntity(client, datasource);
+        case 'monitoredService': return new MonitoredServiceEntity(client, datasource);
         case 'node': return new NodeEntity(client, datasource);
+        case 'outage': return new OutageEntity(client, datasource);
+        case 'snmpInterface': return new SnmpInterfaceEntity(client, datasource);
     }
 
     throw new Error('Unable to get entity for ' + JSON.stringify(e));
@@ -263,10 +293,18 @@ export class OpenNMSEntityDatasource {
     try {
         const functions = FunctionFormatter.findFunctions(q);
         for (const func of functions) {
-            if (func.name === 'nodes') {
-                return new NodeEntity(this.opennmsClient, this);
-            } else if (func.name === 'alarms') {
+            if (func.name === 'alarms') {
                 return new AlarmEntity(this.opennmsClient, this);
+            } else if (func.name === 'ipInterfaces') {
+                return new IpInterfaceEntity(this.opennmsClient, this);
+            } else if (func.name === 'monitoredServices') {
+                return new MonitoredServiceEntity(this.opennmsClient, this);
+            } else if (func.name === 'nodes') {
+                return new NodeEntity(this.opennmsClient, this);
+            } else if (func.name === 'outages') {
+                return new OutageEntity(this.opennmsClient, this);
+            } else if (func.name === 'snmpInterfaces') {
+                return new SnmpInterfaceEntity(this.opennmsClient, this);
             }
         }
     } catch (e) {
@@ -311,12 +349,19 @@ export class OpenNMSEntityDatasource {
     let e = entity;
     const functions = FunctionFormatter.findFunctions(attribute);
     for (const func of functions) {
-      if (func.name === 'nodes') {
-            e = new NodeEntity(entity.client, this);
-            attribute = func.arguments[0] || 'id';
-        } else if (func.name === 'alarms') {
+        attribute = func.arguments[0] || 'id';
+        if (func.name === 'alarms') {
             e = new AlarmEntity(entity.client, this);
-            attribute = func.arguments[0] || 'id';
+        } else if (func.name === 'ipInterfaces') {
+            e = new IpInterfaceEntity(entity.client, this);
+        } else if (func.name === 'monitoredServices') {
+            e = new MonitoredServiceEntity(entity.client, this);
+        } else if (func.name === 'nodes') {
+            e = new NodeEntity(entity.client, this);
+        } else if (func.name === 'outages') {
+            e = new OutageEntity(entity.client, this);
+        } else if (func.name === 'snmpInterfaces') {
+            e = new SnmpInterfaceEntity(entity.client, this);
         }
         // TODO: add nodeFilter() support (requires OpenNMS.js update)
     }

--- a/src/lib/client_delegate.ts
+++ b/src/lib/client_delegate.ts
@@ -116,14 +116,6 @@ export class ClientDelegate {
             .then((client) => this.$q.when(client.nodes()));
     }
 
-    getIpInterfaceDao(): angular.IPromise<DAO.IpInterfaceDAO> {
-        return this.getClientWithMetadata()
-            .then((client) => this.$q.when(client.ipInterfaces()))
-            .catch((err) => {
-                console.warn('This OpenNMS does not support the api/v2/ipinterfaces API');
-            });
-    }
-
     findNodes(filter: API.Filter, fetchPrimaryInterfaces = false): angular.IPromise<Model.OnmsNode[]> {
         return this.$q.all([this.getClientWithMetadata(), this.getNodeDao(), this.getIpInterfaceDao()])
             .then(async ([client, nodeDao, ipInterfaceDao]) => {
@@ -177,7 +169,8 @@ export class ClientDelegate {
 
     getNodeProperties(): angular.IPromise<any[]> {
         return this.getNodeDao()
-            .then((nodeDao) => this.$q.when(nodeDao.searchProperties())).catch(this.decorateError);
+            .then((nodeDao) => this.$q.when(nodeDao.searchProperties()))
+            .catch(this.decorateError);
     }
 
     findNodeProperty(propertyId) {
@@ -189,6 +182,198 @@ export class ClientDelegate {
 
     getNodePropertyComparators(propertyId): angular.IPromise<any[]> {
         return this.findNodeProperty(propertyId)
+            .then(property => {
+                if (property) {
+                    const comparators = property.type.getComparators();
+                    if (comparators && comparators.length > 0) {
+                        return comparators;
+                    }
+                }
+                console.warn(`No comparators found for property with id '${propertyId}'. Falling back to EQ.`);
+                // This may be the case when the user entered a property, which does not exist
+                // therefore fallback to EQ
+                return [ API.Comparators.EQ ];
+            }).catch(this.decorateError);
+    }
+
+    // IP interface related functions
+
+    getIpInterfaceDao(): angular.IPromise<DAO.IpInterfaceDAO> {
+        return this.getClientWithMetadata()
+            .then((client) => this.$q.when(client.ipInterfaces()));
+    }
+
+    findIpInterfaces(filter): angular.IPromise<Model.OnmsIpInterface[]> {
+        return this.getIpInterfaceDao()
+            .then((dao) => this.$q.when(dao.find(filter)))
+            .catch(this.decorateError);
+    }
+
+    getIpInterfaces(id): angular.IPromise<Model.OnmsIpInterface> {
+        return this.getIpInterfaceDao()
+            .then((dao) => this.$q.when(dao.get(id)))
+            .catch(this.decorateError);
+    }
+
+    getIpInterfaceProperties(): angular.IPromise<any[]> {
+        return this.getIpInterfaceDao()
+            .then((dao) => this.$q.when(dao.searchProperties()))
+            .catch(this.decorateError);
+    }
+
+    findIpInterfaceProperty(propertyId) {
+        return this.getIpInterfaceProperties()
+            .then((properties) => {
+                return _.find(properties, (property) => property.id === propertyId);
+            });
+    }
+
+    getIpInterfacePropertyComparators(propertyId): angular.IPromise<any[]> {
+        return this.findIpInterfaceProperty(propertyId)
+            .then(property => {
+                if (property) {
+                    const comparators = property.type.getComparators();
+                    if (comparators && comparators.length > 0) {
+                        return comparators;
+                    }
+                }
+                console.warn(`No comparators found for property with id '${propertyId}'. Falling back to EQ.`);
+                // This may be the case when the user entered a property, which does not exist
+                // therefore fallback to EQ
+                return [ API.Comparators.EQ ];
+            }).catch(this.decorateError);
+    }
+
+    // SNMP interface related functions
+
+    getSnmpInterfaceDao(): angular.IPromise<DAO.SnmpInterfaceDAO> {
+        return this.getClientWithMetadata()
+            .then((client) => this.$q.when(client.snmpInterfaces()));
+    }
+
+    findSnmpInterfaces(filter): angular.IPromise<Model.OnmsSnmpInterface[]> {
+        return this.getSnmpInterfaceDao()
+            .then((dao) => this.$q.when(dao.find(filter)))
+            .catch(this.decorateError);
+    }
+
+    getSnmpInterfaces(id): angular.IPromise<Model.OnmsSnmpInterface> {
+        return this.getSnmpInterfaceDao()
+            .then((dao) => this.$q.when(dao.get(id)))
+            .catch(this.decorateError);
+    }
+
+    getSnmpInterfaceProperties(): angular.IPromise<any[]> {
+        return this.getSnmpInterfaceDao()
+            .then((dao) => this.$q.when(dao.searchProperties()))
+            .catch(this.decorateError);
+    }
+
+    findSnmpInterfaceProperty(propertyId) {
+        return this.getSnmpInterfaceProperties()
+            .then((properties) => {
+                return _.find(properties, (property) => property.id === propertyId);
+            });
+    }
+
+    getSnmpInterfacePropertyComparators(propertyId): angular.IPromise<any[]> {
+        return this.findSnmpInterfaceProperty(propertyId)
+            .then(property => {
+                if (property) {
+                    const comparators = property.type.getComparators();
+                    if (comparators && comparators.length > 0) {
+                        return comparators;
+                    }
+                }
+                console.warn(`No comparators found for property with id '${propertyId}'. Falling back to EQ.`);
+                // This may be the case when the user entered a property, which does not exist
+                // therefore fallback to EQ
+                return [ API.Comparators.EQ ];
+            }).catch(this.decorateError);
+    }
+
+    // monitored service related functions
+
+    getMonitoredServiceDao(): angular.IPromise<DAO.MonitoredServiceDAO> {
+        return this.getClientWithMetadata()
+            .then((client) => this.$q.when(client.monitoredServices()));
+    }
+
+    findMonitoredServices(filter): angular.IPromise<Model.OnmsMonitoredService[]> {
+        return this.getMonitoredServiceDao()
+            .then((dao) => this.$q.when(dao.find(filter)))
+            .catch(this.decorateError);
+    }
+
+    getMonitoredServices(id): angular.IPromise<Model.OnmsMonitoredService> {
+        return this.getMonitoredServiceDao()
+            .then((dao) => this.$q.when(dao.get(id)))
+            .catch(this.decorateError);
+    }
+
+    getMonitoredServiceProperties(): angular.IPromise<any[]> {
+        return this.getMonitoredServiceDao()
+            .then((dao) => this.$q.when(dao.searchProperties()))
+            .catch(this.decorateError);
+    }
+
+    findMonitoredServiceProperty(propertyId) {
+        return this.getMonitoredServiceProperties()
+            .then((properties) => {
+                return _.find(properties, (property) => property.id === propertyId);
+            });
+    }
+
+    getMonitoredServicePropertyComparators(propertyId): angular.IPromise<any[]> {
+        return this.findMonitoredServiceProperty(propertyId)
+            .then(property => {
+                if (property) {
+                    const comparators = property.type.getComparators();
+                    if (comparators && comparators.length > 0) {
+                        return comparators;
+                    }
+                }
+                console.warn(`No comparators found for property with id '${propertyId}'. Falling back to EQ.`);
+                // This may be the case when the user entered a property, which does not exist
+                // therefore fallback to EQ
+                return [ API.Comparators.EQ ];
+            }).catch(this.decorateError);
+    }
+
+    // outage related functions
+
+    getOutageDao(): angular.IPromise<DAO.OutageDAO> {
+        return this.getClientWithMetadata()
+            .then((client) => this.$q.when(client.outages()));
+    }
+
+    findOutages(filter): angular.IPromise<Model.OnmsOutage[]> {
+        return this.getOutageDao()
+            .then((dao) => this.$q.when(dao.find(filter)))
+            .catch(this.decorateError);
+    }
+
+    getOutages(id): angular.IPromise<Model.OnmsOutage> {
+        return this.getOutageDao()
+            .then((dao) => this.$q.when(dao.get(id)))
+            .catch(this.decorateError);
+    }
+
+    getOutageProperties(): angular.IPromise<any[]> {
+        return this.getOutageDao()
+            .then((dao) => this.$q.when(dao.searchProperties()))
+            .catch(this.decorateError);
+    }
+
+    findOutageProperty(propertyId) {
+        return this.getOutageProperties()
+            .then((properties) => {
+                return _.find(properties, (property) => property.id === propertyId);
+            });
+    }
+
+    getOutagePropertyComparators(propertyId): angular.IPromise<any[]> {
+        return this.findOutageProperty(propertyId)
             .then(property => {
                 if (property) {
                     const comparators = property.type.getComparators();


### PR DESCRIPTION
This PR implements entity datasource support for IP interfaces, SNMP interfaces, monitored services, and outages.

Note that for complete testing, you may want the Horizon version from [this companion PR](https://github.com/OpenNMS/opennms/pull/3608) that implements a number of missing options from the properties search used to autocomplete restrictions in Helm:

<img width="523" alt="Screen Shot 2021-08-26 at 1 20 32 PM" src="https://user-images.githubusercontent.com/89252/131007922-fcccc24f-7972-4f2a-95be-da2035fc3f71.png">

(It will work without it, just have a more limited set of options for testing.)

# External References

* JIRA (Issue Tracker): http://issues.opennms.org/browse/HELM-228
* Continuous Integration: [CircleCI](https://circleci.com/gh/OpenNMS/opennms-helm)
