### PR TITLE
HELM-299: support multiple flow queries per panel

### DIFF
--- a/docs/modules/datasources/pages/flow_datasource.adoc
+++ b/docs/modules/datasources/pages/flow_datasource.adoc
@@ -90,6 +90,3 @@ Assuming that the `$node` variable is populated with a value from the `exporterN
 ```
 dscpOnExporterNodeAndInterface($node, $interface, $__from, $__to)
 ```
-== Limitations
-
-The flow datasource only supports a single query per panel.

--- a/src/datasources/entity-ds/Entity.ts
+++ b/src/datasources/entity-ds/Entity.ts
@@ -3,8 +3,6 @@ import { ClientDelegate } from 'lib/client_delegate';
 import { AttributeMapping } from './mapping/AttributeMapping';
 import { Filter } from './ui/Filter';
 
-import angular from 'angular';
-
 export default class Entity {
   abstract name: string;
   abstract type: string;

--- a/src/datasources/entity-ds/datasource.ts
+++ b/src/datasources/entity-ds/datasource.ts
@@ -81,7 +81,7 @@ export class OpenNMSEntityDatasource {
     this.url = instanceSettings.url;
     this.name = instanceSettings.name;
     this.q = $q;
-    this.opennmsClient = new ClientDelegate(instanceSettings, backendSrv, $q);
+    this.opennmsClient = new ClientDelegate(instanceSettings, backendSrv);
 
     // When enabled in the datasource, the grafana user should be used instead of the datasource username on
     // supported operations

--- a/src/test/entity_ds_datasource.spec.ts
+++ b/src/test/entity_ds_datasource.spec.ts
@@ -687,7 +687,7 @@ describe("OpenNMS_Entity_Datasource", function() {
            };
 
            // Instantiate and try to do any operation on the delegate
-           const delegate = new ClientDelegate(ctx.settings, ctx.backendSrv, ctx.$q);
+           const delegate = new ClientDelegate(ctx.settings, ctx.backendSrv);
            delegate.getClientWithMetadata().then(() => {
                done();
            });
@@ -707,7 +707,7 @@ describe("OpenNMS_Entity_Datasource", function() {
            };
 
            // Instantiate and try to do any operation on the delegate
-           const delegate = new ClientDelegate(ctx.settings, ctx.backendSrv, ctx.$q);
+           const delegate = new ClientDelegate(ctx.settings, ctx.backendSrv);
            delegate.getClientWithMetadata().catch(err => {
                expect(err.message).toEqual("Unsupported Version");
                done();

--- a/src/test/flow_ds_datasource.spec.ts
+++ b/src/test/flow_ds_datasource.spec.ts
@@ -1,13 +1,15 @@
 import { FlowDatasource } from '../datasources/flow-ds/datasource';
 import {TemplateSrv} from "./template_srv";
+import {dateTimeAsMoment} from "@grafana/data";
+import {OnmsFlowSeries} from "opennms/src/model/OnmsFlowSeries";
 
 describe("OpenNMS_Flow_Datasource", function () {
 
-  const flowDatasource = new FlowDatasource({ url: "http://localhost" }, null as any, null, new TemplateSrv())
+  const flowDatasource = new FlowDatasource({ url: "http://localhost" }, null as any, new TemplateSrv())
 
   let flowSeriesExample = {
-    "start": 1516358909932,
-    "end": 1516373309932,
+    "start": dateTimeAsMoment(1516358909932),
+    "end": dateTimeAsMoment(1516373309932),
     "columns": [
       {
         "label": "domain",
@@ -29,11 +31,11 @@ describe("OpenNMS_Flow_Datasource", function () {
         2
       ]
     ]
-  };
+  } as OnmsFlowSeries
 
   describe('Mapping', function () {
     it("should map series response to Grafana series", function (done) {
-      let actualResponse = flowDatasource.toSeries({}, flowSeriesExample);
+      let actualResponse = flowDatasource.toSeries({ metric: '', refId: ''}, flowSeriesExample);
       let expectedResponse = [
         {
           "datapoints": [
@@ -55,13 +57,15 @@ describe("OpenNMS_Flow_Datasource", function () {
         }
       ];
 
-      expect(expectedResponse).toEqual(actualResponse);
+      expect(actualResponse).toEqual(expectedResponse);
       done();
     });
 
 
     it("should combine ingress and egress when set", function (done) {
       let target = {
+        metric: '',
+        refId: '',
         'functions': [
           {
             'name': 'combineIngressEgress'
@@ -87,6 +91,8 @@ describe("OpenNMS_Flow_Datasource", function () {
 
     it("should convert bytes to bits when set", function (done) {
       let target = {
+        metric: '',
+        refId: '',
         'functions': [
           {
             'name': 'toBits'
@@ -121,6 +127,8 @@ describe("OpenNMS_Flow_Datasource", function () {
 
     it("should only show ingress when set", function (done) {
       let target = {
+        metric: '',
+        refId: '',
         'functions': [
           {
             'name': 'onlyIngress'
@@ -146,6 +154,8 @@ describe("OpenNMS_Flow_Datasource", function () {
 
     it("should only show egress when set", function (done) {
       let target = {
+        metric: '',
+        refId: '',
         'functions': [
           {
             'name': 'onlyEgress'
@@ -171,6 +181,8 @@ describe("OpenNMS_Flow_Datasource", function () {
 
     it("should apply prefix and suffix to labels when set", function (done) {
       let target = {
+        metric: '',
+        refId: '',
         'functions': [
           {
             'name': 'withPrefix',

--- a/src/test/flow_ds_datasource.spec.ts
+++ b/src/test/flow_ds_datasource.spec.ts
@@ -57,7 +57,7 @@ describe("OpenNMS_Flow_Datasource", function () {
         }
       ];
 
-      expect(actualResponse).toEqual(expectedResponse);
+      expect(expectedResponse).toEqual(actualResponse);
       done();
     });
 


### PR DESCRIPTION
Issue: https://issues.opennms.org/browse/HELM-299

This PR lifts the restriction that only a single query is allowed for a panel.

* In case of time series, no additional actions are necessary: Grafana graphs all the time series in the graph panel.
* In case of summary tables, Grafana's `Merge` transformation can be used to merge several tables into a single table

In addition, this PR removes some legacy dependencies on Angular. In particular, current Grafana versions do no longer require the usage of Angular's `IPromise` but support the usage of the standard `Promise`.