### PR TITLE
HELM-293: support string properties in performance datasource

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -37,19 +37,19 @@ defaults: &defaults
     from_branch:
       description: the auto-merge source branch
       type: string
-      default: "release-7.x"
+      default: develop
     from_branch_label:
       description: the auto-merge source branch (escaped, no slashes)
       type: string
-      default: "release-7.x"
+      default: develop
     to_branch:
       description: the auto-merge target branch
       type: string
-      default: develop
+      default: master
     to_branch_label:
       description: the auto-merge target branch (escaped, no slashes)
       type: string
-      default: develop
+      default: master
 
 docker_container_config: &docker_container_config
   executor: docker-executor

--- a/docs/modules/datasources/pages/performance_datasource.adoc
+++ b/docs/modules/datasources/pages/performance_datasource.adoc
@@ -41,12 +41,19 @@ Use Grafana's transforms like "Filter by name", "Organize Fields", or "Merge" to
 
 [options="header, autowidth"]
 |===
-| Name               | Description
-| Node               | Node ID of the node to query.
+| Name
+| Description
+
+| Node
+| Node ID of the node to query.
 Can also be a variable with a `nodeFilter()` query.
-| Resource           | Resource ID containing the requested attribute.
+
+| Resource
+| Resource ID containing the requested attribute.
 Can also be a variable with a `nodeResources()` query.
-| String Property    | Name of the attribute to query.
+
+| String Property
+| Name of the attribute to query.
 |===
 
 === Expression queries

--- a/docs/modules/datasources/pages/performance_datasource.adoc
+++ b/docs/modules/datasources/pages/performance_datasource.adoc
@@ -33,7 +33,11 @@ The query is used to identify which attribute (or series) is being queried.
 
 === String property queries
 
-Used to read the last value of string valued properties that OpenNMS collects and stores. The query is used to identify which string property is queried. A panel can contain multiple string property queries. The result can be visualized in a table. Grafana's transforms like "Filter by name", "Organize Fields", or "Merge" can be used to adjust the visualized table as needed.
+Used to read the last value of string-valued properties that OpenNMS collects and stores.
+The query identifies which string property is queried. 
+A panel can contain multiple string property queries. 
+The result can be visualized in a table. 
+Use Grafana's transforms like "Filter by name", "Organize Fields", or "Merge" to adjust the visualized table as needed.
 
 [options="header, autowidth"]
 |===

--- a/docs/modules/datasources/pages/performance_datasource.adoc
+++ b/docs/modules/datasources/pages/performance_datasource.adoc
@@ -31,6 +31,20 @@ The query is used to identify which attribute (or series) is being queried.
                        Must be unique for all attributes and expression results in the query.
 |===
 
+=== String property queries
+
+Used to read the last value of string valued properties that OpenNMS collects and stores. The query is used to identify which string property is queried. A panel can contain multiple string property queries. The result can be visualized in a table. Grafana's transforms like "Filter by name", "Organize Fields", or "Merge" can be used to adjust the visualized table as needed.
+
+[options="header, autowidth"]
+|===
+| Name               | Description
+| Node               | Node ID of the node to query.
+Can also be a variable with a `nodeFilter()` query.
+| Resource           | Resource ID containing the requested attribute.
+Can also be a variable with a `nodeResources()` query.
+| String Property    | Name of the attribute to query.
+|===
+
 === Expression queries
 
 Used to combine or otherwise transform one or more series into a new series.

--- a/src/datasources/perf-ds/constants.ts
+++ b/src/datasources/perf-ds/constants.ts
@@ -1,5 +1,8 @@
+export const STRING_PROPERTY_TYPE = 'stringProperty'
+
 export const QueryType = Object.freeze({
   Attribute: 'attribute',
   Expression: 'expression',
-  Filter: 'filter'
+  Filter: 'filter',
+  'String Property': STRING_PROPERTY_TYPE
 });

--- a/src/datasources/perf-ds/datasource.ts
+++ b/src/datasources/perf-ds/datasource.ts
@@ -105,6 +105,10 @@ export class OpenNMSDatasource {
     return request.targets.every(query => query.type === STRING_PROPERTY_TYPE)
   }
 
+  someQueriesAreStringPropertyQueries(request: DataQueryRequest<PerfQuery>): boolean {
+    return request.targets.some(query => query.type === STRING_PROPERTY_TYPE)
+  }
+
   queryStringPropertiesOfNode(nodeId: string, queries: DefinedStringPropertyQuery[]): Promise<DataQueryResponseData[]> {
     return this.doOpenNMSRequest({
       url: '/rest/resources/fornode/' + encodeURIComponent(nodeId),
@@ -208,7 +212,10 @@ export class OpenNMSDatasource {
   query(options: any) {
     if (this.allQueriesAreStringPropertyQueries(options)) {
       return this.queryStringProperties(options)
+    } else if (this.someQueriesAreStringPropertyQueries(options)) {
+      throw new Error("string property queries can not be mixed with other kinds of queries")
     }
+
 
     const self = this;
 

--- a/src/datasources/perf-ds/datasource.ts
+++ b/src/datasources/perf-ds/datasource.ts
@@ -1,8 +1,10 @@
-import {QueryType} from './constants';
+import {QueryType, STRING_PROPERTY_TYPE} from './constants';
 import {interpolate} from "./interpolate";
 import _ from 'lodash';
 import {FunctionFormatter} from '../../lib/function_formatter';
 import angular from 'angular';
+import {DataQuery, DataQueryRequest, DataQueryResponse, FieldType} from "@grafana/data";
+import {DataQueryResponseData} from "@grafana/data/types/datasource";
 
 interface Query {
   start: number;
@@ -13,6 +15,22 @@ interface Query {
   source: any[];
   expression: any[];
   filter: any;
+}
+
+interface PerfQuery extends DataQuery {
+  type?: string
+}
+
+interface StringPropertyQuery extends PerfQuery {
+  nodeId?: string
+  resourceId?: string
+  stringProperty?: string
+}
+
+type DefinedStringPropertyQuery = Required<StringPropertyQuery>
+
+function isDefinedStringPropertyQuery(q: StringPropertyQuery | undefined): q is DefinedStringPropertyQuery {
+  return q !== undefined && !!q.nodeId && !!q.resourceId && !!q.stringProperty
 }
 
 export class OpenNMSDatasource {
@@ -40,7 +58,7 @@ export class OpenNMSDatasource {
     }
   }
 
-  doOpenNMSRequest(options: any) {
+  doOpenNMSRequest(options: any): Promise<any> {
     if (this.basicAuth || this.withCredentials) {
       options.withCredentials = true;
     }
@@ -83,7 +101,115 @@ export class OpenNMSDatasource {
     return this.$q.reject(ret);
   }
 
+  allQueriesAreStringPropertyQueries(request: DataQueryRequest<PerfQuery>): boolean {
+    return request.targets.every(query => query.type === STRING_PROPERTY_TYPE)
+  }
+
+  queryStringPropertiesOfNode(nodeId: string, queries: DefinedStringPropertyQuery[]): Promise<DataQueryResponseData[]> {
+    return this.doOpenNMSRequest({
+      url: '/rest/resources/fornode/' + encodeURIComponent(nodeId),
+      method: 'GET',
+      headers: {'Content-Type': 'application/json'}
+    }).then(response => {
+      return queries.flatMap(query => {
+        return response.data.children.resource
+            .filter(resource => (resource.id as string).endsWith(`.${query.resourceId}`))
+            .flatMap(resource => this.extractStringProperty(query, resource, response.data))
+      })
+    })
+  }
+
+  /*
+  // not used for now because the node label is not available when subresources are queried directly
+  queryStringPropertiesOfResource(query: DefinedStringPropertyQuery): Promise<DataQueryResponseData[]> {
+    return this.doOpenNMSRequest({
+      url: '/rest/resources/node[' + query.nodeId + '].' + query.resourceId,
+      method: 'GET',
+      headers: {'Content-Type': 'application/json'}
+    }).then(response => {
+      // no node data is available when a resource is directly addressed
+      // -> no node label is available
+      return this.extractStringProperty(query, response.data, undefined)
+    })
+  }
+  */
+
+  extractStringProperty(query: DefinedStringPropertyQuery, resource: any, node?: any): DataQueryResponseData[] {
+    return Object.keys(resource.stringPropertyAttributes)
+        .filter(key => key === query.stringProperty)
+        .flatMap(key => {
+          return {
+            refId: query.refId,
+            fields: [
+              {
+                name: 'nodeId',
+                type: FieldType.string,
+                config: {},
+                values: [query.nodeId]
+              },
+              {
+                name: 'nodeLabel',
+                type: FieldType.string,
+                values: [node ? node.label : query.nodeId]
+              },
+              {
+                name: 'resourceId',
+                type: FieldType.string,
+                config: {},
+                values: [query.resourceId]
+              },
+              {
+                name: 'resourceLabel',
+                type: FieldType.string,
+                config: {},
+                values: [resource.label]
+              },
+              {
+                name: key,
+                type: FieldType.string,
+                config: {},
+                values: [resource.stringPropertyAttributes[key]]
+              }
+            ]
+          }
+        })
+  }
+
+  queryStringProperties(request: DataQueryRequest<StringPropertyQuery>): Promise<DataQueryResponse> {
+    const definedQueries = request.targets
+        .filter(q => !q.hide)
+        .filter(isDefinedStringPropertyQuery)
+        .map(q => {
+          return {
+            ...q,
+            nodeId: this.templateSrv.replace(q.nodeId),
+            resourceId: this.templateSrv.replace(q.resourceId)
+          }
+        })
+    const groupedByNodeId = definedQueries.reduce<{ [key: string]: DefinedStringPropertyQuery[] }>((accu, query) => {
+      (accu[query.nodeId] = accu[query.nodeId] || []).push(query)
+      return accu
+    }, {})
+    const datas: Array<Promise<DataQueryResponseData[]>> =
+        // send a request for each node separately and query the complete node resource
+        // -> may be optimized in future, by batch querying for multiple nodes in one go and returning only relevant parts
+        //    (could be activated by a feature toggle in opennms-js/ServerMetadata)
+        Object.keys(groupedByNodeId).map((nodeId) => {
+          const queries = groupedByNodeId[nodeId]
+          return this.queryStringPropertiesOfNode(nodeId, queries)
+        })
+    return Promise.all(datas).then(datas => {
+      return {
+        data: datas.flatMap(x => x)
+      }
+    })
+  }
+
   query(options: any) {
+    if (this.allQueriesAreStringPropertyQueries(options)) {
+      return this.queryStringProperties(options)
+    }
+
     const self = this;
 
     // Generate the query
@@ -556,4 +682,30 @@ export class OpenNMSDatasource {
       return attributes;
     });
   }
+
+  suggestStringProperties(nodeId: string, resourceId: string, query: string) {
+    var interpolatedNodeId = _.first(this.interpolateValue(nodeId)),
+        interpolatedResourceId = _.first(this.interpolateValue(resourceId));
+    var remoteResourceId = OpenNMSDatasource.getRemoteResourceId(interpolatedNodeId, interpolatedResourceId);
+
+    return this.doOpenNMSRequest({
+      url: '/rest/resources/' + encodeURIComponent(remoteResourceId),
+      method: 'GET',
+      params: {
+        depth: -1
+      }
+    }).then(function (results) {
+      query = query.toLowerCase();
+      var stringProperties = [] as any[];
+      _.each(results.data.stringPropertyAttributes, function (value, key) {
+        if (key.toLowerCase().indexOf(query) >= 0) {
+          stringProperties.push(key);
+        }
+      });
+      stringProperties.sort();
+
+      return stringProperties;
+    });
+  }
+
 }

--- a/src/datasources/perf-ds/partials/query.editor.html
+++ b/src/datasources/perf-ds/partials/query.editor.html
@@ -122,6 +122,65 @@
         </div>
     </div>
 
+    <div ng-show="ctrl.target.type === 'stringProperty'">
+        <div class="gf-form-inline">
+            <div class="gf-form max-width-25">
+                <a class="gf-form-label query-keyword width-10"
+                   ng-click="ctrl.openNodeSelectionModal();"
+                   role="menuitem">
+                    Node <i class="fa fa-tree"></i>
+                </a>
+                <input type="text" ng-required="true"
+                       class="gf-form-input"
+                       ng-model="ctrl.target.nodeId"
+                       spellcheck='false'
+
+                       placeholder="node id"
+                       data-min-length=0 data-items=100
+                       ng-blur="ctrl.targetBlur('nodeId')"
+                >
+            </div>
+        </div>
+        <div class="gf-form-inline" ng-show="ctrl.target.nodeId">
+            <div class="gf-form max-width-25">
+                <a class="gf-form-label query-keyword width-10"
+                   ng-click="ctrl.openResourceSelectionModal();"
+                   role="menuitem">
+                    Resource <i class="fa fa-leaf"></i>
+                </a>
+                <input type="text" ng-required="true"
+                       class="gf-form-input"
+                       ng-model="ctrl.target.resourceId"
+                       spellcheck='false'
+
+                       placeholder="resource id"
+                       data-min-length=0 data-items=100
+                       ng-blur="ctrl.targetBlur('resourceId')"
+                >
+            </div>
+        </div>
+        <div ng-show="ctrl.target.resourceId">
+            <div class="gf-form-inline">
+                <div class="gf-form max-width-25">
+                    <a class="gf-form-label query-keyword width-10"
+                       ng-click="ctrl.openStringPropertySelectionModal('stringProperty');"
+                       role="menuitem">
+                        String Property<i class="fa fa-tag"></i>
+                    </a>
+                    <input type="text" ng-required="true"
+                           class="gf-form-input"
+                           ng-model="ctrl.target.stringProperty"
+                           spellcheck='false'
+
+                           placeholder="string"
+                           data-min-length=0 data-items=100
+                           ng-blur="ctrl.targetBlur('stringProperty')"
+                    >
+                </div>
+            </div>
+        </div>
+    </div>
+
     <div class="gf-form-inline" ng-show="ctrl.target.type === 'expression'">
         <div class="gf-form max-width">
             <label class="gf-form-label query-keyword width-10">
@@ -178,7 +237,7 @@
         </div>
     </div>
 
-    <div class="gf-form-inline" ng-show="ctrl.target.type && ctrl.target.type !== 'filter'">
+    <div class="gf-form-inline" ng-show="ctrl.target.type && ctrl.target.type !== 'filter' && ctrl.target.type !== 'stringProperty'">
         <div class="gf-form max-width-25">
             <label class="gf-form-label query-keyword width-10">
                 Label <i class="fa fa-font"></i>

--- a/src/datasources/perf-ds/partials/query.options.html
+++ b/src/datasources/perf-ds/partials/query.options.html
@@ -32,6 +32,12 @@
                 &nbsp;template queries
             </a>
         </span>
+        <span class="gf-form-label width-10">
+            <a ng-click="ctrl.panelCtrl.toggleEditorHelp(6);" bs-tooltip="'click to show helpful info'" data-placement="bottom">
+              <i class="fa fa-info-circle"></i>
+                &nbsp;string properties
+            </a>
+        </span>
       </div>
     </div>
   </div>
@@ -86,6 +92,13 @@
             <li>nodeResources(FS:FID)</li>
           </ul>
         </li>
+      </ul>
+    </div>
+
+    <div class="grafana-info-box span6" ng-if="ctrl.panelCtrl.editorHelpIndex === 6">
+      <h5>String Properties</h5>
+      <ul>
+        <li>Click on the label with the icon to search the available string property names.</li>
       </ul>
     </div>
   </div>

--- a/src/datasources/perf-ds/query_ctrl.ts
+++ b/src/datasources/perf-ds/query_ctrl.ts
@@ -161,6 +161,36 @@ export class OpenNMSQueryCtrl extends QueryCtrl {
     );
   }
 
+  openStringPropertySelectionModal(prop) {
+    var self = this;
+
+    if (!prop) {
+      prop = 'attribute';
+    }
+
+    this.showSelectionModal(
+        'attributes',
+        {
+          Name: 'name',
+        },
+        function (query) {
+          return self.datasource
+              .suggestStringProperties(self.target.nodeId, self.target.resourceId, query)
+              .then((stringProperties: string[]) => {
+                const named = stringProperties.map(s => { return { name: s } })
+                return {
+                  totalCount: named.length,
+                  rows: named,
+                };
+              });
+        },
+        function (attribute) {
+          self.target[prop] = attribute.name;
+          self.targetBlur(prop);
+        }
+    );
+  }
+
   openFilterSelectionModal() {
     var self = this;
     this.showSelectionModal(


### PR DESCRIPTION
Issue: https://issues.opennms.org/browse/HELM-293

This PR adds support for querying string properties to the performance datasource.

@Bonrob2 I also added some documentation; please review.

Open question: I added some help text into `query.options.html` but did not find where this would show up when using the performance datasource. Is the help functiionality broken?
