### PR TITLE
AR/jira/HELM-305: Helm's Flow datasource cannot filter "NaN" results, breaking Grafana reduce expressions

### DIFF
--- a/docs/modules/datasources/pages/flow_datasource.adoc
+++ b/docs/modules/datasources/pages/flow_datasource.adoc
@@ -25,6 +25,7 @@ The query editor supports the following functions:
 | Transform | `withGroupByInterval`   | Changes the resolution of the returned datapoints grouping by the given time interval (in the format of: 10s, 5m, 1h, etc.).
 | Transform | `withPrefix`            | Specifies a prefix for graph and summary labels.
 | Transform | `withSuffix`            | Specifies a suffix for graph and summary labels.
+| Transform | `nanToZero`             | Convert all NaN values to zero (0) so they can be taken in consideration by reduce expressions.
 |===
 
 

--- a/src/datasources/flow-ds/datasource.ts
+++ b/src/datasources/flow-ds/datasource.ts
@@ -389,6 +389,7 @@ export class FlowDatasource {
     let combineIngressEgress = FlowDatasource.isFunctionPresent(query, 'combineIngressEgress');
     let onlyIngress = FlowDatasource.isFunctionPresent(query, 'onlyIngress');
     let onlyEgress = FlowDatasource.isFunctionPresent(query, 'onlyEgress');
+    let nanToZero = FlowDatasource.isFunctionPresent(query, 'nanToZero');
 
     let start = flowSeries.start.valueOf();
     let end = flowSeries.end.valueOf();
@@ -424,8 +425,8 @@ export class FlowDatasource {
                       .filter(({column}) => column.label === col.label)
                       // get the values of those columns ...
                       .map(({colIdx}) => {
-                        const v = Number(values[colIdx][timestampIdx])
-                        return isNaN(v) ? 0 : v
+                        const v = values[colIdx][timestampIdx]
+                       return isNaN(Number(v)) && nanToZero ? 0 : v 
                       })
                       // ... and sum them up
                       .reduce((previous, current) => previous + (current ? current : 0), 0)
@@ -449,7 +450,7 @@ export class FlowDatasource {
             const datapoints = timestampsInRange
                 .map(({timestamp, timestampIdx}) => {
                   const v = Number(values[colIdx][timestampIdx])
-                  return [isNaN(v) ? 0 : v * multiplier * sign, timestamp]
+                  return [isNaN(v) ? nanToZero ? 0 : null : v * multiplier * sign, timestamp]
                 })
 
             return {

--- a/src/datasources/flow-ds/datasource.ts
+++ b/src/datasources/flow-ds/datasource.ts
@@ -423,7 +423,10 @@ export class FlowDatasource {
                       // determine the indexes of those columns that have the same label as the current column
                       .filter(({column}) => column.label === col.label)
                       // get the values of those columns ...
-                      .map(({colIdx}) => values[colIdx][timestampIdx])
+                      .map(({colIdx}) => {
+                        const v = Number(values[colIdx][timestampIdx])
+                        return isNaN(v) ? 0 : v
+                      })
                       // ... and sum them up
                       .reduce((previous, current) => previous + (current ? current : 0), 0)
                   return [sum * multiplier, timestamp]
@@ -445,8 +448,8 @@ export class FlowDatasource {
 
             const datapoints = timestampsInRange
                 .map(({timestamp, timestampIdx}) => {
-                  const v = values[colIdx][timestampIdx]
-                  return [v === null || v === undefined || Number.isNaN(v) ? null : v * multiplier * sign, timestamp]
+                  const v = Number(values[colIdx][timestampIdx])
+                  return [isNaN(v) ? 0 : v * multiplier * sign, timestamp]
                 })
 
             return {

--- a/src/datasources/flow-ds/flow_functions.ts
+++ b/src/datasources/flow-ds/flow_functions.ts
@@ -135,6 +135,7 @@ addFuncDef({
 addFuncDef({
   name: 'nanToZero',
   cardinality: Cardinality.SINGLE,
+  mutuallyExcludes: ['asTableSummary'],
   category: categories.Transform
 });
 

--- a/src/datasources/flow-ds/flow_functions.ts
+++ b/src/datasources/flow-ds/flow_functions.ts
@@ -133,6 +133,12 @@ addFuncDef({
 });
 
 addFuncDef({
+  name: 'nanToZero',
+  cardinality: Cardinality.SINGLE,
+  category: categories.Transform
+});
+
+addFuncDef({
   name: 'negativeEgress',
   cardinality: Cardinality.SINGLE,
   mutuallyExcludes: ['asTableSummary'],

--- a/src/test/flow_ds_datasource.spec.ts
+++ b/src/test/flow_ds_datasource.spec.ts
@@ -246,13 +246,53 @@ describe("OpenNMS_Flow_Datasource", function () {
       done();
     })
 
-    it("should convert 'NaN' values in response to Grafana series", function (done) {
-      let actualResponse = flowDatasource.toSeries({ metric: '', refId: ''}, flowSeriesExampleNaN);
+    it("should convert 'NaN' to 0 values in response to Grafana series", function (done) {
+      let target = {
+        metric: '',
+        refId: '',
+        'functions': [
+          {
+            'name': 'nanToZero'
+          }
+        ]
+      };
+      let actualResponse = flowDatasource.toSeries(target, flowSeriesExampleNaN);
       let expectedResponse = [
         {
           "datapoints": [
             [
               0,
+              1516358909932
+            ]
+          ],
+          "target": "domain (In)"
+        },
+        {
+          "datapoints": [
+            [
+              2,
+              1516358909932
+            ]
+          ],
+          "target": "domain (Out)"
+        }
+      ];
+
+      expect(expectedResponse).toEqual(actualResponse);
+      done();
+    });
+
+    it("should convert 'NaN' to null values in response to Grafana series", function (done) {
+      let target = {
+        metric: '',
+        refId: ''
+      };
+      let actualResponse = flowDatasource.toSeries(target, flowSeriesExampleNaN);
+      let expectedResponse = [
+        {
+          "datapoints": [
+            [
+              null,
               1516358909932
             ]
           ],

--- a/src/test/flow_ds_datasource.spec.ts
+++ b/src/test/flow_ds_datasource.spec.ts
@@ -33,6 +33,32 @@ describe("OpenNMS_Flow_Datasource", function () {
     ]
   } as OnmsFlowSeries
 
+  let flowSeriesExampleNaN = {
+    "start": dateTimeAsMoment(1516358909932),
+    "end": dateTimeAsMoment(1516373309932),
+    "columns": [
+      {
+        "label": "domain",
+        "ingress": true
+      },
+      {
+        "label": "domain",
+        "ingress": false
+      }
+    ],
+    "timestamps": [
+      1516358909932
+    ],
+    "values": [
+      [
+        "NaN"
+      ],
+      [
+        2
+      ]
+    ]
+  } as OnmsFlowSeries
+
   describe('Mapping', function () {
     it("should map series response to Grafana series", function (done) {
       let actualResponse = flowDatasource.toSeries({ metric: '', refId: ''}, flowSeriesExample);
@@ -219,6 +245,33 @@ describe("OpenNMS_Flow_Datasource", function () {
       expect(expectedResponse).toEqual(actualResponse);
       done();
     })
+
+    it("should convert 'NaN' values in response to Grafana series", function (done) {
+      let actualResponse = flowDatasource.toSeries({ metric: '', refId: ''}, flowSeriesExampleNaN);
+      let expectedResponse = [
+        {
+          "datapoints": [
+            [
+              0,
+              1516358909932
+            ]
+          ],
+          "target": "domain (In)"
+        },
+        {
+          "datapoints": [
+            [
+              2,
+              1516358909932
+            ]
+          ],
+          "target": "domain (Out)"
+        }
+      ];
+
+      expect(expectedResponse).toEqual(actualResponse);
+      done();
+    });
 
   });
 


### PR DESCRIPTION
I believe the issue was a bug in the flows datasource for series(Nan values were actual string NaN, so Number.isNaN was retruning incorrect values). There is no need to create a Transformation for filter NaN unless is for an especific scenario where this grouping is needed.

Reduce Expression should be able to use Number type values from the flow series datasoiurces.


* JIRA (Issue Tracker): http://issues.opennms.org/browse/HELM-305
* Continuous Integration: [CircleCI](https://circleci.com/gh/OpenNMS/opennms-helm)
