### PR TITLE
HELM-309: Grafana Datasource expressions - Performance

### DIFF
--- a/src/datasources/perf-ds/datasource.ts
+++ b/src/datasources/perf-ds/datasource.ts
@@ -508,7 +508,7 @@ export class OpenNMSDatasource {
    * @returns Node Id 
    */
   static getNodeId(resource): string {
-    const matches = resource.match(/node(Source)?\[([^\]*)?\]\..*/);
+    const matches = resource.match(/node(Source)?\[([^\]]*)?\]\..*/);
     if (matches && matches.length === 3){
       return matches[2];
     }

--- a/src/datasources/perf-ds/datasource.ts
+++ b/src/datasources/perf-ds/datasource.ts
@@ -508,7 +508,7 @@ export class OpenNMSDatasource {
    * @returns Node Id 
    */
   static getNodeId(resource): string {
-    const matches = resource.match(/node(Source)?\[(.*)?\]\..*/);
+    const matches = resource.match(/node(Source)?\[([^\]*)?\]\..*/);
     if (matches && matches.length === 3){
       return matches[2];
     }

--- a/src/datasources/perf-ds/datasource.ts
+++ b/src/datasources/perf-ds/datasource.ts
@@ -521,7 +521,7 @@ export class OpenNMSDatasource {
    * @returns Resource Id
    */
   static getResourceId(resource): string {
-    const matches = resource.match(/node(Source)?\[.*?\]\.(.*)/);
+    const matches = resource.match(/node(Source)?\[[^\]]*?\]\.(.*)/);
     if (matches && matches.length === 3){
       return matches[2];
     }

--- a/src/datasources/perf-ds/datasource.ts
+++ b/src/datasources/perf-ds/datasource.ts
@@ -279,9 +279,9 @@ export class OpenNMSDatasource {
       request = Promise.all(self.extendedQuery(query))
         .then((sources) => {
           _.each(sources, (source) => {
-            if (source.length > 0)
+            if (source.length > 0){
               query.source = query.source.concat(source);
-
+            }
           })
           return query;
         })
@@ -344,11 +344,11 @@ export class OpenNMSDatasource {
    * @param query query created from buildQuery 
    * @returns 
    */
-  extendedQuery(query: Query): Promise<any>[] {
+  extendedQuery(query: Query): Array<Promise<any>> {
     let self = this;
     let sourceClone = lodashClonedeep(query.source);
 
-    const promises: Promise<any>[] = [];
+    const promises: Array<Promise<any>> = [];
     const globSources = self.getGlobExpressionsOnly(sourceClone);
 
 
@@ -386,7 +386,7 @@ export class OpenNMSDatasource {
       });
   }
 
-  generateMatchingSourcesForMatchingProperties(matchingProps: Map<string, string>[], source: any, propsToMatch: Map<AllowedProperties, string>): any[] {
+  generateMatchingSourcesForMatchingProperties(matchingProps: Array<Map<string, string>>, source: any, propsToMatch: Map<AllowedProperties, string>): any[] {
     const result: any[] = [];
     //iterate attributes matches
     _.each(matchingProps, (pairs) => {
@@ -417,21 +417,21 @@ export class OpenNMSDatasource {
    * @param nodeId 
    * @returns 
    */
-  getMatchingProperties(response: any, properties: Map<AllowedProperties, string>, nodeId: string): Map<string, string>[] {
+  getMatchingProperties(response: any, properties: Map<AllowedProperties, string>, nodeId: string): Array<Map<string, string>> {
 
     //check if resource id matches
-    const result: Map<string, string>[] = [];
+    const result: Array<Map<string, string>> = [];
     if (response.id && response.hasOwnProperty('rrdGraphAttributes')) {
       const resourceId = OpenNMSDatasource.getResourceId(response.id);
 
       const resourceIdPattern = OpenNMSDatasource.getResourceId(properties.get(AllowedProperties.ResourceId));
-      if (!resourceIdPattern) return result;
+      if (!resourceIdPattern) { return result; }
       const regexResourceId = new RegExp(resourceIdPattern);
-      if (!regexResourceId.test(resourceId)) return result;
+      if (!regexResourceId.test(resourceId)) { return result; }
 
       _.forOwn(response.rrdGraphAttributes, (obj, id) => {
         const attributePattern = properties.get(AllowedProperties.Attribute);
-        if (!attributePattern) return;
+        if (!attributePattern)  { return; }
         const regex = new RegExp(attributePattern);
         if (regex.test(id)) {
           const match: Map<string, string> = new Map<string, string>();
@@ -492,10 +492,12 @@ export class OpenNMSDatasource {
   getGlobQueries(source: any): Map<AllowedProperties, string> {
     const props: Map<AllowedProperties, string> = new Map<AllowedProperties, string>();
     _.forIn(AllowedProperties, (value, key) => {
-      if (value === AllowedProperties.ResourceId)
+      if (value === AllowedProperties.ResourceId){
         props.set(value, OpenNMSGlob.getGlobAsRegexPattern(OpenNMSDatasource.getResourceId(source[value])));
-      else
-        props.set(value, OpenNMSGlob.getGlobAsRegexPattern(source[value]))
+      }
+      else {
+        props.set(value, OpenNMSGlob.getGlobAsRegexPattern(source[value]));
+      }
     });
     return props;
   }
@@ -507,9 +509,10 @@ export class OpenNMSDatasource {
    */
   static getNodeId(resource): string {
     const matches = resource.match(/node(Source)?\[(.*)?\]\..*/);
-    if (matches && matches.length == 3)
+    if (matches && matches.length === 3){
       return matches[2];
-    else return resource;
+    }
+    else { return resource; }
   }
 
   /**
@@ -519,9 +522,10 @@ export class OpenNMSDatasource {
    */
   static getResourceId(resource): string {
     const matches = resource.match(/node(Source)?\[.*?\]\.(.*)/);
-    if (matches && matches.length == 3)
+    if (matches && matches.length === 3){
       return matches[2];
-    else return resource;
+    }
+    else { return resource; }
   }
 
   // Used by template queries

--- a/src/datasources/perf-ds/datasource.ts
+++ b/src/datasources/perf-ds/datasource.ts
@@ -1,12 +1,12 @@
-import { QueryType, STRING_PROPERTY_TYPE } from './constants';
-import { interpolate } from "./interpolate";
+import {QueryType, STRING_PROPERTY_TYPE} from './constants';
+import {interpolate} from "./interpolate";
 import _ from 'lodash';
-import { FunctionFormatter } from '../../lib/function_formatter';
-import { DataQuery, DataQueryRequest, DataQueryResponse, Field, FieldType } from "@grafana/data";
-import { DataQueryResponseData } from "@grafana/data/types/datasource";
-import { ClientDelegate } from '../../lib/client_delegate'
-import { OpenNMSGlob } from '../../lib/utils'
-import { Client, ServerMetadata } from 'opennms'
+import {FunctionFormatter} from '../../lib/function_formatter';
+import {DataQuery, DataQueryRequest, DataQueryResponse, Field, FieldType} from "@grafana/data";
+import {DataQueryResponseData} from "@grafana/data/types/datasource";
+import {ClientDelegate} from '../../lib/client_delegate'
+import {OpenNMSGlob} from '../../lib/utils'
+import {Client, ServerMetadata} from 'opennms'
 
 const lodashClonedeep = require('lodash.clonedeep');
 
@@ -39,7 +39,7 @@ function isDefinedStringPropertyQuery(q: StringPropertyQuery | undefined): q is 
 
 
 
-enum AllowedProperties {
+export enum AllowedProperties {
   ResourceId = "resourceId",
   Attribute = "attribute"
 };
@@ -67,7 +67,7 @@ export class OpenNMSDatasource {
     this.interval = (instanceSettings.jsonData || {}).timeInterval;
 
     if (instanceSettings.jsonData && instanceSettings.jsonData.timeout) {
-      this.timeout = parseInt(instanceSettings.jsonData.timeout, 10) * 1000;
+        this.timeout = parseInt(instanceSettings.jsonData.timeout,10) * 1000;
     }
   }
 
@@ -142,8 +142,8 @@ export class OpenNMSDatasource {
     }).then(response => {
       return queries.flatMap(query => {
         return response.data.children.resource
-          .filter(resource => (resource.id as string).endsWith(`.${query.resourceId}`))
-          .flatMap(resource => this.extractStringProperty(query, resource, response.data))
+            .filter(resource => (resource.id as string).endsWith(`.${query.resourceId}`))
+            .flatMap(resource => this.extractStringProperty(query, resource, response.data))
       })
     })
   }
@@ -158,55 +158,55 @@ export class OpenNMSDatasource {
         stringProperties: Array.from(selection.stringProperties).join(',')
       }
     }).then(response =>
-      response.data.flatMap(node =>
-        node.children.resource.flatMap(resource =>
-          Object.entries<string>(resource.stringPropertyAttributes).flatMap(([key, value]) => {
-            return {
-              fields: OpenNMSDatasource.fields({
-                nodeId: node.name,
-                nodeLabel: node.label,
-                resourceId: resource.name,
-                resourceLabel: resource.label,
-                stringPropertyKey: key,
-                stringPropertyValue: value
-              })
-            }
-          }
-          )
+        response.data.flatMap(node =>
+            node.children.resource.flatMap(resource =>
+                Object.entries<string>(resource.stringPropertyAttributes).flatMap(([key, value]) => {
+                      return {
+                        fields: OpenNMSDatasource.fields({
+                          nodeId: node.name,
+                          nodeLabel: node.label,
+                          resourceId: resource.name,
+                          resourceLabel: resource.label,
+                          stringPropertyKey: key,
+                          stringPropertyValue: value
+                        })
+                      }
+                    }
+                )
+            )
         )
-      )
     )
   }
 
   private extractStringProperty(query: DefinedStringPropertyQuery, resource: any, node?: any): DataQueryResponseData[] {
     return Object.keys(resource.stringPropertyAttributes)
-      .filter(key => key === query.stringProperty)
-      .flatMap(key => {
-        return {
-          refId: query.refId,
-          fields: OpenNMSDatasource.fields({
-            nodeId: query.nodeId,
-            nodeLabel: node ? node.label : query.nodeId,
-            resourceId: query.resourceId,
-            resourceLabel: resource.label,
-            stringPropertyKey: key,
-            stringPropertyValue: resource.stringPropertyAttributes[key]
-          })
-        }
-      })
+        .filter(key => key === query.stringProperty)
+        .flatMap(key => {
+          return {
+            refId: query.refId,
+            fields: OpenNMSDatasource.fields({
+              nodeId: query.nodeId,
+              nodeLabel: node ? node.label : query.nodeId,
+              resourceId: query.resourceId,
+              resourceLabel: resource.label,
+              stringPropertyKey: key,
+              stringPropertyValue: resource.stringPropertyAttributes[key]
+            })
+          }
+        })
   }
 
   queryStringProperties(request: DataQueryRequest<StringPropertyQuery>): Promise<DataQueryResponse> {
     const definedQueries: DefinedStringPropertyQuery[] = request.targets
-      .filter(q => !q.hide)
-      .filter(isDefinedStringPropertyQuery)
-      .map(q => {
-        return {
-          ...q,
-          nodeId: this.templateSrv.replace(q.nodeId),
-          resourceId: this.templateSrv.replace(q.resourceId)
-        }
-      })
+        .filter(q => !q.hide)
+        .filter(isDefinedStringPropertyQuery)
+        .map(q => {
+          return {
+            ...q,
+            nodeId: this.templateSrv.replace(q.nodeId),
+            resourceId: this.templateSrv.replace(q.resourceId)
+          }
+        })
     return this.clientDelegate.getClientWithMetadata().then((client: Client) => {
       const metadata: ServerMetadata = client.http.server.metadata;
       if (metadata.selectPartialResources()) {
@@ -220,12 +220,12 @@ export class OpenNMSDatasource {
   queryStringPropertiesForAllNodesInBulk(definedQueries: DefinedStringPropertyQuery[]): Promise<DataQueryResponse> {
     // send a single request that selects all nodes, subresources, and string properties
     const selection =
-      definedQueries.reduce<{ nodes: Set<string>, nodeSubresources: Set<string>, stringProperties: Set<string> }>((accu, query) => {
-        accu.nodes.add(query.nodeId)
-        accu.nodeSubresources.add(query.resourceId)
-        accu.stringProperties.add(query.stringProperty)
-        return accu
-      }, { nodes: new Set(), nodeSubresources: new Set(), stringProperties: new Set() })
+        definedQueries.reduce<{ nodes: Set<string>, nodeSubresources: Set<string>, stringProperties: Set<string> }>((accu, query) => {
+          accu.nodes.add(query.nodeId)
+          accu.nodeSubresources.add(query.resourceId)
+          accu.stringProperties.add(query.stringProperty)
+          return accu
+        }, {nodes: new Set(), nodeSubresources: new Set(), stringProperties: new Set()})
     return this.queryAllStringProperties(selection).then(datas => {
       return {
         data: datas
@@ -240,10 +240,10 @@ export class OpenNMSDatasource {
     }, {})
     // send a request for each node separately...
     const datas: Array<Promise<DataQueryResponseData[]>> =
-      Object.keys(groupedByNodeId).map((nodeId) => {
-        const queries = groupedByNodeId[nodeId]
-        return this.queryStringPropertiesOfNode(nodeId, queries)
-      })
+        Object.keys(groupedByNodeId).map((nodeId) => {
+          const queries = groupedByNodeId[nodeId]
+          return this.queryStringPropertiesOfNode(nodeId, queries)
+        })
     // ... and then combine all results into a single DataQueryResponse
     return Promise.all(datas).then(datas => {
       return {
@@ -258,12 +258,12 @@ export class OpenNMSDatasource {
       return this.queryStringProperties(options)
     } else if (queries.some(query => query.type === STRING_PROPERTY_TYPE)) {
       return Promise.resolve(
-        {
-          data: [],
-          error: {
-            message: "string property queries can not be mixed with other kinds of queries"
+          {
+            data: [],
+            error: {
+              message: "string property queries can not be mixed with other kinds of queries"
+            }
           }
-        }
       )
     }
 
@@ -302,7 +302,7 @@ export class OpenNMSDatasource {
       // Convert the results to the expected format
       .then((response) => {
         if (response.status < 200 || response.status >= 300) {
-          console.warn('Response code:', response);
+          console.warn('Response code:',response);
           return Promise.reject(response);
         }
 
@@ -310,8 +310,8 @@ export class OpenNMSDatasource {
       })
       // Sort resulting series by labels
       .then((result) => {
-        result.data = _.sortBy(result.data, (s) => _.indexOf(labels, s.label));
-        return result;
+          result.data = _.sortBy(result.data, (s) => _.indexOf(labels, s.label));
+          return result;
       })
       .catch(err => {
         return Promise.reject(self.decorateError(err));
@@ -325,7 +325,7 @@ export class OpenNMSDatasource {
       method: 'GET'
     }).then(response => {
       if (response.status === 200) {
-        return { status: "success", message: "Data source is working", title: "Success" };
+        return {status: "success", message: "Data source is working", title: "Success"};
       } else {
         return {
           status: "danger",
@@ -567,7 +567,7 @@ export class OpenNMSDatasource {
         if (node.foreignId !== null && node.foreignSource !== null) {
           nodeCriteria = node.foreignSource + ":" + node.foreignId;
         }
-        results.push({ text: node.label, value: nodeCriteria, expandable: true });
+        results.push({text: node.label, value: nodeCriteria, expandable: true});
       });
       return results;
     });
@@ -607,7 +607,7 @@ export class OpenNMSDatasource {
             console.warn(`Unknown resource property '${textProperty}' specified. Using 'id' instead.`);
         }
         if ((resourceType === '*' && resourceWithoutNodePrefix) || (resourceWithoutNodePrefix[2].indexOf(resourceType + '[') === 0)) {
-          results.push({ text: textValue, value: resourceWithoutNodePrefix[2], expandable: true });
+          results.push({text: textValue, value: resourceWithoutNodePrefix[2], expandable: true});
         }
       });
       return results;
@@ -622,7 +622,7 @@ export class OpenNMSDatasource {
       start = options.range.from.valueOf(),
       end = options.range.to.valueOf(),
       step = Math.floor((end - start) / maxDataPoints);
-    step = (step < intervalMs) ? intervalMs : step;
+      step = (step < intervalMs) ? intervalMs : step;
 
     var query = {
       start: start,
@@ -643,7 +643,7 @@ export class OpenNMSDatasource {
       }
 
       if (target.type === QueryType.Attribute) {
-        if (!(target.nodeId && target.resourceId && target.attribute)) {
+        if (!((target.nodeId && target.resourceId && target.attribute))) {
           return;
         }
 
@@ -672,9 +672,9 @@ export class OpenNMSDatasource {
 
         // Perform variable substitution - may generate additional queries
         source = self.interpolateSourceVariables(source, options.scopedVars, (interpolatedSource: any) => {
-          // Calculate the effective resource id after the interpolation
-          interpolatedSource.resourceId = OpenNMSDatasource.getRemoteResourceId(interpolatedSource.nodeId, interpolatedSource.resourceId);
-          delete interpolatedSource.nodeId;
+            // Calculate the effective resource id after the interpolation
+            interpolatedSource.resourceId = OpenNMSDatasource.getRemoteResourceId(interpolatedSource.nodeId, interpolatedSource.resourceId);
+            delete interpolatedSource.nodeId;
         });
         query.source = query.source.concat(source);
 
@@ -749,7 +749,7 @@ export class OpenNMSDatasource {
   }
 
   interpolateValue(value: any, scopedVars?: any) {
-    return _.map(this.interpolateVariables({ 'value': value }, ['value'], scopedVars), function (entry) {
+    return _.map(this.interpolateVariables({'value': value}, ['value'], scopedVars), function(entry) {
       return entry.value;
     });
   }
@@ -757,7 +757,7 @@ export class OpenNMSDatasource {
   interpolateVariables(object: any, attributes: any, scopedVars: any, callback?: (value: any) => void) {
     // Reformat the variables to work with our interpolate function
     var variables = [] as any[];
-    _.each(this.templateSrv.variables, function (templateVariable) {
+    _.each(this.templateSrv.variables, function(templateVariable) {
       var variable = {
         name: templateVariable.name,
         value: [] as any[]
@@ -771,9 +771,9 @@ export class OpenNMSDatasource {
         if (_.isString(templateVariable.current.value)) {
           variable.value.push(templateVariable.current.value);
         } else {
-          _.each(templateVariable.current.value, function (value) {
+          _.each(templateVariable.current.value, function(value) {
             if (value === "$__all") {
-              _.each(templateVariable.options, function (option) {
+              _.each(templateVariable.options, function(option) {
                 // "All" is part of the options, so make sure to skip that one
                 if (option.value !== "$__all") {
                   variable.value.push(option.value);
@@ -843,7 +843,7 @@ export class OpenNMSDatasource {
       }
     }
 
-    return { data: series };
+    return {data: series};
   }
 
   static flattenResourcesWithAttributes(resources, resourcesWithAttributes) {
@@ -915,7 +915,7 @@ export class OpenNMSDatasource {
 
   suggestAttributes(nodeId: string, resourceId: string, query: string) {
     var interpolatedNodeId = _.first(this.interpolateValue(nodeId)),
-      interpolatedResourceId = _.first(this.interpolateValue(resourceId));
+        interpolatedResourceId = _.first(this.interpolateValue(resourceId));
     var remoteResourceId = OpenNMSDatasource.getRemoteResourceId(interpolatedNodeId, interpolatedResourceId);
 
     return this.doOpenNMSRequest({
@@ -940,7 +940,7 @@ export class OpenNMSDatasource {
 
   suggestStringProperties(nodeId: string, resourceId: string, query: string) {
     var interpolatedNodeId = _.first(this.interpolateValue(nodeId)),
-      interpolatedResourceId = _.first(this.interpolateValue(resourceId));
+        interpolatedResourceId = _.first(this.interpolateValue(resourceId));
     var remoteResourceId = OpenNMSDatasource.getRemoteResourceId(interpolatedNodeId, interpolatedResourceId);
 
     return this.doOpenNMSRequest({

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -274,7 +274,7 @@ export class OpenNMSGlob {
   private static globExpressions: string[] = ['*', '|'];
 
   static getGlobAsRegexPattern(expr: string) {
-    return _.escapeRegExp(expr).replace('\\*', '.*').replace('\\|', '|');
+    return _.escapeRegExp(expr).replace(/\\\*/ig, '.*').replace(/\\\|/ig, '|');
   }
 
   /**

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -288,6 +288,7 @@ export class OpenNMSGlob {
       return _.includes(OpenNMSGlob.globExpressions, char);
     });
   }
+}
 
 /**
  * Swap items in an array

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -269,3 +269,22 @@ export function processSelectionVariables(input?: string[]): string[] {
       return []
   }
 }
+
+export class OpenNMSGlob {
+  private static globExpressions: string[] = ['*', '|'];
+
+  static getGlobAsRegexPattern(expr: string) {
+    return _.escapeRegExp(expr).replace('\\*', '.*').replace('\\|', '|');
+  }
+
+  /**
+   * Check if expression contains allowed glob characters
+   * @param expr expression
+   * @returns true if expression contains allowed glob characters ('*', '|')
+   */
+  static hasGlob(expr: string): boolean {
+    return _.some([...expr], (char) => {
+      return _.includes(OpenNMSGlob.globExpressions, char);
+    });
+  }
+}

--- a/src/test/perf_ds_datasource.spec.ts
+++ b/src/test/perf_ds_datasource.spec.ts
@@ -3,6 +3,7 @@ const warn = console.warn;
 console.warn = () => {};
 
 import { Datasource } from '../datasources/perf-ds/module';
+import { AllowedProperties } from '../datasources/perf-ds/datasource';
 
 console.warn = warn;
 

--- a/src/test/perf_ds_datasource.spec.ts
+++ b/src/test/perf_ds_datasource.spec.ts
@@ -451,5 +451,178 @@ describe('OpenNMSPMDatasource', function () {
           expect(result.data[2].datapoints).toStrictEqual([[9, 0], [9, 5], [9, 10]]);
       });
 
+    it('should identify source with glob expressions only', function () {
+      let options = {
+        range: { from: 'now-1h', to: 'now' },
+        targets: [
+          {
+            type: "attribute",
+            nodeId: '1',
+            resourceId: 'nodeSnmp[*]',
+            attribute: 'loadavg5|loadavg5',
+            aggregation: 'AVERAGE'
+          },
+          {
+            type: "attribute",
+            nodeId: '1',
+            resourceId: 'nodeSnmp[]',
+            attribute: 'loadavg1',
+            aggregation: 'AVERAGE'
+          }
+        ],
+        interval: '1s'
+      };
+
+      let [query,] = ctx.ds.buildQuery(options);
+      let globSources = ctx.ds.getGlobExpressionsOnly(query.source);
+      expect(query.source.length).toEqual(2);
+      expect(globSources.size).toEqual(1);
+    });
+
+    it('Get matches from response with | glob expression', function () {
+
+      let response = {
+        "id": "node[selfmonitor:1].nodeSnmp[]",
+        "label": "",
+        "name": "",
+        "link": null,
+        "typeLabel": "",
+        "parentId": "node[selfmonitor:1]",
+        "children": {
+          "totalCount": null,
+          "count": null,
+          "offset": 0,
+          "resource": []
+        },
+        "stringPropertyAttributes": {},
+        "externalValueAttributes": {},
+        "rrdGraphAttributes": {
+          "loadavg11": {
+            "name": "loadavg11",
+            "relativePath": "/path/to/loadavg11",
+            "rrdFile": "loadavg11.jrb"
+          },
+          "loadavg12": {
+            "name": "loadavg12",
+            "relativePath": "/path/to/loadavg12",
+            "rrdFile": "loadavg12.jrb"
+          },
+          "loadavg23": {
+            "name": "loadavg23",
+            "relativePath": "/path/to/loadavg23",
+            "rrdFile": "loadavg23.jrb"
+          },
+          "loadavg21": {
+            "name": "loadavg21",
+            "relativePath": "/path/to/loadavg21",
+            "rrdFile": "loadavg21.jrb"
+          }
+
+        }
+      };
+
+      let options = {
+        range: { from: 'now-1h', to: 'now' },
+        targets: [
+          {
+            type: "attribute",
+            nodeId: '1',
+            resourceId: 'nodeSnmp[]',
+            attribute: 'loadavg11|loadavg12',
+            aggregation: 'AVERAGE'
+          }
+        ],
+        interval: '1s'
+      };
+
+
+      let [query,] = ctx.ds.buildQuery(options);
+
+      const propsToMatch: Map<AllowedProperties, string> = ctx.ds.getGlobQueries(query.source[0]);
+
+      const matchingProps = ctx.ds.getMatchingProperties(response, propsToMatch, '1');
+
+      const sources = ctx.ds.generateMatchingSourcesForMatchingProperties(matchingProps, query.source[0], propsToMatch);
+
+      expect(propsToMatch.size).toEqual(2);
+      expect(matchingProps.length).toEqual(2);
+      expect(sources.length).toEqual(2);
+      expect(sources[0].attribute).toEqual('loadavg11');
+      expect(sources[1].attribute).toEqual('loadavg12');
+    });
+
+    it('Get matches from response with * glob expression', function () {
+
+      let response = {
+        "id": "node[selfmonitor:1].nodeSnmp[]",
+        "label": "",
+        "name": "",
+        "link": null,
+        "typeLabel": "",
+        "parentId": "node[selfmonitor:1]",
+        "children": {
+          "totalCount": null,
+          "count": null,
+          "offset": 0,
+          "resource": []
+        },
+        "stringPropertyAttributes": {},
+        "externalValueAttributes": {},
+        "rrdGraphAttributes": {
+          "loadavg11": {
+            "name": "loadavg11",
+            "relativePath": "/path/to/loadavg11",
+            "rrdFile": "loadavg11.jrb"
+          },
+          "loadavg12": {
+            "name": "loadavg12",
+            "relativePath": "/path/to/loadavg12",
+            "rrdFile": "loadavg12.jrb"
+          },
+          "loadavg23": {
+            "name": "loadavg23",
+            "relativePath": "/path/to/loadavg23",
+            "rrdFile": "loadavg23.jrb"
+          },
+          "loadavg21": {
+            "name": "loadavg21",
+            "relativePath": "/path/to/loadavg21",
+            "rrdFile": "loadavg21.jrb"
+          }
+
+        }
+      };
+
+      let options = {
+        range: { from: 'now-1h', to: 'now' },
+        targets: [
+          {
+            type: "attribute",
+            nodeId: '1',
+            resourceId: 'nodeSnmp[]',
+            attribute: 'loadavg2*',
+            aggregation: 'AVERAGE'
+          }
+        ],
+        interval: '1s'
+      };
+
+
+      let [query,] = ctx.ds.buildQuery(options);
+
+      const propsToMatch: Map<AllowedProperties, string> = ctx.ds.getGlobQueries(query.source[0]);
+
+      const matchingProps = ctx.ds.getMatchingProperties(response, propsToMatch, '1');
+
+      const sources = ctx.ds.generateMatchingSourcesForMatchingProperties(matchingProps, query.source[0], propsToMatch);
+
+      expect(propsToMatch.size).toEqual(2);
+      expect(matchingProps.length).toEqual(2);
+      expect(sources.length).toEqual(2);
+      expect(sources[0].attribute).toEqual('loadavg23');
+      expect(sources[1].attribute).toEqual('loadavg21');
+    });
+
+   
   });
 });


### PR DESCRIPTION
Added functionlity to allow Glob expressions ('*' and '|' )in order to query multiple resources and attributes from the performance datasource using a single query. (See images below with result samples)

![Screen Shot 2022-04-04 at 4 58 34 PM](https://user-images.githubusercontent.com/3297292/161631228-9b7dc480-2409-4138-abdc-a7f4feef952a.png)


![Screen Shot 2022-04-04 at 5 01 52 PM](https://user-images.githubusercontent.com/3297292/161631673-22d1ba3c-feb9-42e2-a9fd-49a0a53ae7ef.png)


# External References

* JIRA (Issue Tracker): http://issues.opennms.org/browse/HELM-309
* Continuous Integration: [CircleCI](https://circleci.com/gh/OpenNMS/opennms-helm)
