### PR TITLE
HELM-320: FlowDS's combineIngressEgress transform loses the first query response result

### DIFF
--- a/src/datasources/flow-ds/datasource.ts
+++ b/src/datasources/flow-ds/datasource.ts
@@ -441,18 +441,16 @@ export class FlowDatasource {
     }
 
     if (combineIngressEgress) {
-      const ingressColumns =  flowSeries.columns.filter(column => column.ingress);
-      const egressColumns =  flowSeries.columns.filter(column => !column.ingress);
-      const columns = ingressColumns.length >= egressColumns.length ? ingressColumns : egressColumns;
-
-      return columns          
+      const uniqueColumns =  [...new Set(flowSeries.columns.map(col => col.label))];
+      
+      return uniqueColumns          
           .map(col => {
 
             const datapoints = timestampsInRange
                 .map(({timestamp, timestampIdx}) => {
                   const sum = columnsWithIndex
                       // determine the indexes of those columns that have the same label as the current column
-                      .filter(({column}) => column.label === col.label)
+                      .filter(({column}) => column.label === col)
                       // get the values of those columns ...
                       .map(({colIdx}) => {
                         const v = values[colIdx][timestampIdx]
@@ -464,7 +462,7 @@ export class FlowDatasource {
                 })
 
             return {
-              target: _.flow(ensuredLabelTranformer, prefixSuffixLabelTransformer)(col.label),
+              target: _.flow(ensuredLabelTranformer, prefixSuffixLabelTransformer)(col),
               datapoints
             }
           })

--- a/src/datasources/flow-ds/datasource.ts
+++ b/src/datasources/flow-ds/datasource.ts
@@ -441,10 +441,11 @@ export class FlowDatasource {
     }
 
     if (combineIngressEgress) {
+      const ingressColumns =  flowSeries.columns.filter(column => column.ingress);
+      const egressColumns =  flowSeries.columns.filter(column => !column.ingress);
+      const columns = ingressColumns.length >= egressColumns.length ? ingressColumns : egressColumns;
 
-      return flowSeries.columns
-          // use the ingress columns to drive the calculation of combined series
-          .filter(column => column.ingress)
+      return columns          
           .map(col => {
 
             const datapoints = timestampsInRange

--- a/src/test/flow_ds_datasource.spec.ts
+++ b/src/test/flow_ds_datasource.spec.ts
@@ -566,6 +566,7 @@ describe("OpenNMS_Flow_Datasource", function () {
         ]
       };
       let actualResponse = flowDatasource.toSeries(target,  flowSeriesExampleCalc);
+      
       let expectedResponse = [
         {
           "datapoints": [
@@ -589,6 +590,38 @@ describe("OpenNMS_Flow_Datasource", function () {
       ];
 
       expect(expectedResponse).toEqual(actualResponse);
+
+      flowSeriesExampleCalc.columns.push(
+        {
+        "label": "domain1",
+        "ingress": false
+      });
+      flowSeriesExampleCalc.values.push([10]);
+      actualResponse = flowDatasource.toSeries(target,  flowSeriesExampleCalc);
+
+      expectedResponse = [
+        {
+          "datapoints": [
+            [
+              3,
+              1516358909932
+            ]
+          ],
+          "target": "domain"
+        }
+        ,
+        {
+          "datapoints": [
+            [
+              15,
+              1516358909932
+            ]
+          ],
+          "target": "domain1"
+        }
+      ];
+      expect(expectedResponse).toEqual(actualResponse);
+
       done();
     });
 

--- a/src/test/flow_ds_datasource.spec.ts
+++ b/src/test/flow_ds_datasource.spec.ts
@@ -8,7 +8,7 @@ describe("OpenNMS_Flow_Datasource", function () {
 
   const flowDatasource = new FlowDatasource({ url: "http://localhost" }, null, new TemplateSrv())
 
-  let flowSeriesExample, flowSeriesExampleNaN, flowSummaryExample, exporterNodes;
+  let flowSeriesExample, flowSeriesExampleNaN, flowSummaryExample, exporterNodes, flowSeriesExampleCalc;
 
   beforeEach(() => {
     
@@ -107,6 +107,39 @@ describe("OpenNMS_Flow_Datasource", function () {
         "expandable": true
       }
     ]
+
+    flowSeriesExampleCalc = {
+      "start": dateTimeAsMoment(1516358909932),
+      "end": dateTimeAsMoment(1516373309932),
+      "columns": [
+        {
+          "label": "domain",
+          "ingress": true
+        },
+        {
+          "label": "domain",
+          "ingress": false
+        },
+        {
+          "label": "domain1",
+          "ingress": false
+        }
+      ],
+      "timestamps": [
+        1516358909932
+      ],
+      "values": [
+        [
+          1
+        ],
+        [
+          2
+        ],
+        [
+          5
+        ]
+      ]
+    } as OnmsFlowSeries
   });
 
   describe('Mapping', function () {
@@ -519,6 +552,43 @@ describe("OpenNMS_Flow_Datasource", function () {
           expect(response).toEqual(expectedResponse); 
         });
       
+      done();
+    });
+
+    it("should combine multiple with uneven qty of ingress and egress when set", function (done) {
+      let target = {
+        metric: '',
+        refId: '',
+        'functions': [
+          {
+            'name': 'combineIngressEgress'
+          }
+        ]
+      };
+      let actualResponse = flowDatasource.toSeries(target,  flowSeriesExampleCalc);
+      let expectedResponse = [
+        {
+          "datapoints": [
+            [
+              3,
+              1516358909932
+            ]
+          ],
+          "target": "domain"
+        }
+        ,
+        {
+          "datapoints": [
+            [
+              5,
+              1516358909932
+            ]
+          ],
+          "target": "domain1"
+        }
+      ];
+
+      expect(expectedResponse).toEqual(actualResponse);
       done();
     });
 


### PR DESCRIPTION
Possible fix for missing records when using combineIngressEgress transformation

* JIRA (Issue Tracker): http://issues.opennms.org/browse/HELM-320
* Continuous Integration: [CircleCI](https://circleci.com/gh/OpenNMS/opennms-helm)
