### PR TITLE
HELM-272: Fix issues found while fixing HELM-272

### DIFF
--- a/src/lib/text_box_variable.ts
+++ b/src/lib/text_box_variable.ts
@@ -1,4 +1,4 @@
-import { assignModelProperties, setOptionAsCurrent, setOptionFromUrl } from './utils';
+import { assignModelProperties, getValueOrFirstElement, setOptionAsCurrent, setOptionFromUrl } from './utils';
 
 export class TextBoxVariable {
   type = 'textbox';
@@ -36,7 +36,9 @@ export class TextBoxVariable {
   }
 
   updateOptions() {
-    this.options = [{ text: this.query.trim(), value: this.query.trim(), selected: false }];
+    const query = (getValueOrFirstElement<string>(this.query) || '').trim();
+
+    this.options = [{ text: query, value: query, selected: false }];
     this.current = this.options[0];
     return Promise.resolve();
   }

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -74,7 +74,12 @@ export function variableUpdated(variable, emitChangeEvents = false) {
   let promises = [] as Array<Promise<any>>;
 
   // in theory we should create an efficient sub-list of variables to update, but for now just do them all YOLO
-  variables.forEach(v => promises.push(v.updateOptions()));
+  variables.forEach(v => {
+    // variables don't always seem to have updateOptions method, so check here
+    if (v.updateOptions) {
+      promises.push(v.updateOptions());
+    }
+  });
 
   templateSrv.setGlobalVariable(variable.id, variable.current);
 
@@ -259,6 +264,14 @@ export function getInputsAsArray(input: string) {
   } else {
     return [input];
   }
+}
+
+/**
+ * Grafana oftens returns values that are either the raw value or else a one-element array with the value.
+ * Utility function to get either.
+ */
+export function getValueOrFirstElement<T>(input: T | T[]): T {
+  return _.isArray(input) && input.length > 0 ? input[0] : (input as T);
 }
 
 /** Checks if the given index is the first index of the given t. */


### PR DESCRIPTION
HELM-272: Fix issues found while fixing HELM-272 which were causing FilterPanel not to update correctly

This needs to be done in conjunction with OpenNMS/opennms HELM-272, [PR](https://github.com/OpenNMS/opennms/pull/4958)

- In `lib/utils.ts`, `variableUpdated`, sometimes variables don't have `updateOptions` method defined, so check first
- In 'lib/utils.ts', added `getValueOrFirstElement()` since sometimes Grafana returns values that are either the raw value or else a one-element array with the value
- In `lib/text_box_variable.ts`, use `getValueOrFirstElement` to prevent `.trim() not found` error 

These issues were preventing Filter value dropdowns/text boxes to appear on Filter Panel

# External References

* JIRA (Issue Tracker): http://issues.opennms.org/browse/HELM-272
* Continuous Integration: [CircleCI](https://circleci.com/gh/OpenNMS/opennms-helm)
