### PR TITLE
HELM-332: HELM: Regex for Grafana Template Variable does not work on labels [Performance Datasource]

### DIFF
--- a/docs/modules/datasources/pages/performance_datasource.adoc
+++ b/docs/modules/datasources/pages/performance_datasource.adoc
@@ -185,7 +185,7 @@ To query a specific node by foreign source and foreign id, you can use an expres
 nodeResources(FS:FID)
 ```
 
-To query only SNMP interface resources on the node with ID 42, and to display the interfaces resources labels rather than their often-cryptic IDs, you might use:
+To query only SNMP interface resources on the node with ID 42, and to display the interface's resource labels rather than their often-cryptic IDs, you might use:
 ```
 nodeResources(42, label, interfaceSnmp)
 ```

--- a/docs/modules/datasources/pages/performance_datasource.adoc
+++ b/docs/modules/datasources/pages/performance_datasource.adoc
@@ -202,7 +202,7 @@ The available arguments are as follows:
 | resourceId        | Required | `(none)` | The ID of the node (either databaseId or foreignSource:foreignId) for which to display resources.
 | textProperty      | Optional | `id`     | One of `id`, `label`, or `name` to display alternate string values in the variable drop-down menu.
 | resourceType      | Optional | `*`      | Resource type filter to limit the types of resources returned.
-| Regular Expression| Optional | RegExp   | Regular Expression to filter the result by textProperty.
+| Regular expression| Optional | RegExp   | Regular expression to filter the result by `textProperty`.
 |===
 
 == Label formatters

--- a/docs/modules/datasources/pages/performance_datasource.adoc
+++ b/docs/modules/datasources/pages/performance_datasource.adoc
@@ -190,6 +190,11 @@ To query only SNMP interface resources on the node with ID 42, and to display th
 nodeResources(42, label, interfaceSnmp)
 ```
 
+To query all resources on the node with ID 42, and labels that match the regular expression \*.DPN.*, you might use:
+```
+nodeResources(42, label, *, .*DPN.*)
+```
+
 The available arguments are as follows:
 [options="header, %autowidth"]
 |===
@@ -197,6 +202,7 @@ The available arguments are as follows:
 | resourceId        | Required | `(none)` | The ID of the node (either databaseId or foreignSource:foreignId) for which to display resources.
 | textProperty      | Optional | `id`     | One of `id`, `label`, or `name` to display alternate string values in the variable drop-down menu.
 | resourceType      | Optional | `*`      | Resource type filter to limit the types of resources returned.
+| Regular Expression| Optional | RegExp   | Regular Expression to filter the result by textProperty.
 |===
 
 == Label formatters

--- a/docs/modules/datasources/pages/performance_datasource.adoc
+++ b/docs/modules/datasources/pages/performance_datasource.adoc
@@ -185,7 +185,7 @@ To query a specific node by foreign source and foreign id, you can use an expres
 nodeResources(FS:FID)
 ```
 
-To query only SNMP interface resources on the node with ID 42, and to display the interfaces resources' labels rather than their often-cryptic IDs, you might use:
+To query only SNMP interface resources on the node with ID 42, and to display the interfaces resources labels rather than their often-cryptic IDs, you might use:
 ```
 nodeResources(42, label, interfaceSnmp)
 ```

--- a/docs/modules/datasources/pages/performance_datasource.adoc
+++ b/docs/modules/datasources/pages/performance_datasource.adoc
@@ -202,7 +202,7 @@ The available arguments are as follows:
 | resourceId        | Required | `(none)` | The ID of the node (either databaseId or foreignSource:foreignId) for which to display resources.
 | textProperty      | Optional | `id`     | One of `id`, `label`, or `name` to display alternate string values in the variable drop-down menu.
 | resourceType      | Optional | `*`      | Resource type filter to limit the types of resources returned.
-| Regular expression| Optional | RegExp   | Regular expression to filter the result by `textProperty`.
+| Regular expression| Optional | RegExp   | Regular expression filter applied to the resource field specified by the `textProperty` argument.
 |===
 
 == Label formatters

--- a/src/datasources/perf-ds/datasource.ts
+++ b/src/datasources/perf-ds/datasource.ts
@@ -560,12 +560,15 @@ export class OpenNMSDatasource {
   }
 
   metricFindNodeResourceQuery(query, ...options) {
-    var textProperty = "id", resourceType = '*';
+    var textProperty = "id", resourceType = '*', regex = null;
     if (options.length > 0) {
       textProperty = options[0];
     }
     if (options.length > 1) {
       resourceType = options[1];
+    }
+    if (options.length > 2) {
+      regex = options[2];
     }
     return this.simpleRequest.doOpenNMSRequest({
       url: '/rest/resources/' + encodeURIComponent(OpenNMSDatasource.getNodeResource(query)),
@@ -592,8 +595,10 @@ export class OpenNMSDatasource {
             textValue = resourceWithoutNodePrefix[2];
             console.warn(`Unknown resource property '${textProperty}' specified. Using 'id' instead.`);
         }
-        if ((resourceType === '*' && resourceWithoutNodePrefix) || (resourceWithoutNodePrefix[2].indexOf(resourceType + '[') === 0)) {
-          results.push({text: textValue, value: resourceWithoutNodePrefix[2], expandable: true});
+        if (((resourceType === '*' && resourceWithoutNodePrefix) || 
+        (resourceWithoutNodePrefix[2].indexOf(resourceType + '[') === 0)) && 
+        (!regex || new RegExp(regex).test(textValue) )) {
+            results.push({text: textValue, value: resourceWithoutNodePrefix[2], expandable: true});
         }
       });
       return results;


### PR DESCRIPTION
Added a new regex attribute to nodeResources template variable function to allow filtering by textProperties when they are used.

* JIRA (Issue Tracker): http://issues.opennms.org/browse/HELM-332
* Continuous Integration: [CircleCI](https://circleci.com/gh/OpenNMS/opennms-helm)
