### PR TITLE
HELM-338: Entity nodeFilter is not working

### DIFF
--- a/src/datasources/entity-ds/datasource.ts
+++ b/src/datasources/entity-ds/datasource.ts
@@ -420,20 +420,28 @@ export class OpenNMSEntityDatasource {
         let filter = new API.Filter();        
 
         if (propValuePair && propValuePair.length === 2) {
-            const propertyKey =  entity.getAttributeMapping().getApiAttribute( propValuePair[0].trim());
+            const propertyKey = entity.getAttributeMapping().getApiAttribute(propValuePair[0].trim());
             const propertyValue = propValuePair[1].trim().replace(/^["'](.+(?=["']$))["']$/, '$1');
-             if(propertyKey && propertyValue){
+            if (propertyValue.trim().startsWith('$')) {
+
+                const variableName = this.templateSrv.getVariableName(propertyValue);
+                const templateVariable = this._getTemplateVariable(variableName);
+                if (templateVariable && templateVariable.current.value) {
+                    filter.withAndRestriction(new API.Restriction(propertyKey, API.Comparators.EQ, templateVariable.current.value));
+                    filter.limit = 0;
+                }
+            } else if (propertyKey && propertyValue) {
                 filter.withAndRestriction(new API.Restriction(propertyKey, API.Comparators.EQ, propertyValue));
                 filter.limit = 0;
             }
         }
-       
+
         return this.opennmsClient.getNodeByFilter(filter)
-        .then(nodes => {
-            return nodes.map(node =>  { 
-                return {id: node.id, label: node.id, text: node.id ? String(node.id) : node.id, value: node.id } 
+            .then(nodes => {
+                return nodes.map(node => {
+                    return { id: node.id, label: node.id, text: node.id ? String(node.id) : node.id, value: node.id }
+                });
             });
-        });
     }
 
     getAlarm(alarmId) {

--- a/src/datasources/entity-ds/datasource.ts
+++ b/src/datasources/entity-ds/datasource.ts
@@ -420,7 +420,7 @@ export class OpenNMSEntityDatasource {
         let filter = new API.Filter();        
 
         if (propValuePair && propValuePair.length === 2) {
-            const propertyKey = entity.getAttributeMapping().getApiAttribute(propValuePair[0].trim());
+            const propertyKey =  entity.getAttributeMapping().getApiAttribute( propValuePair[0].trim());
             const propertyValue = propValuePair[1].trim().replace(/^["'](.+(?=["']$))["']$/, '$1');
             if (propertyValue.trim().startsWith('$')) {
 
@@ -437,11 +437,11 @@ export class OpenNMSEntityDatasource {
         }
 
         return this.opennmsClient.getNodeByFilter(filter)
-            .then(nodes => {
-                return nodes.map(node => {
-                    return { id: node.id, label: node.id, text: node.id ? String(node.id) : node.id, value: node.id }
-                });
+        .then(nodes => {
+            return nodes.map(node =>  {
+                return {id: node.id, label: node.id, text: node.id ? String(node.id) : node.id, value: node.id }
             });
+        });
     }
 
     getAlarm(alarmId) {

--- a/src/datasources/entity-ds/datasource.ts
+++ b/src/datasources/entity-ds/datasource.ts
@@ -422,10 +422,8 @@ export class OpenNMSEntityDatasource {
         if (propValuePair && propValuePair.length === 2) {
             const propertyKey =  entity.getAttributeMapping().getApiAttribute( propValuePair[0].trim());
             const propertyValue = propValuePair[1].trim().replace(/^["'](.+(?=["']$))["']$/, '$1');
-            const variableName = this.templateSrv.getVariableName(propertyValue);
-            const templateVariable = this._getTemplateVariable(variableName);
-            if(templateVariable && templateVariable.current.value){
-                filter.withAndRestriction(new API.Restriction(propertyKey, API.Comparators.EQ, templateVariable.current.value));
+             if(propertyKey && propertyValue){
+                filter.withAndRestriction(new API.Restriction(propertyKey, API.Comparators.EQ, propertyValue));
                 filter.limit = 0;
             }
         }


### PR DESCRIPTION
Fixed the issue with the filter creation when using nodeFilter.

It should filter by passing \<attribute\>='\<value\>' as an argument. And value should be able to be a constant and variable (template_variable)

Now should be able to handle scenarios like 

nodeFilter(location='$location')
and 
nodeFilter(location='Kanata')

nodeFilter(foreignId='$foreignId')
and 
nodeFilter(foreignId='0.0.0.0')

* JIRA (Issue Tracker): http://issues.opennms.org/browse/HELM-338
* Continuous Integration: [CircleCI](https://circleci.com/gh/OpenNMS/opennms-helm)
