### PR TITLE
HELM-336: Flow DS query interfacesOnExporterWithFlows() does not accept FS:FID as argument

### DIFF
--- a/src/datasources/flow-ds/datasource.ts
+++ b/src/datasources/flow-ds/datasource.ts
@@ -238,7 +238,7 @@ export class FlowDatasource {
   }
 
   // Used by template queries
-  metricFindQuery(query) {
+  async metricFindQuery(query) {
     if (query === null || query === undefined || query === "") {
       return Promise.resolve([]);
     }
@@ -332,48 +332,47 @@ export class FlowDatasource {
     return Promise.resolve([]);
   }
 
-  metricFindLocations() {
-    return this.simpleRequest.getLocations();
+  async metricFindLocations() {
+    return await this.simpleRequest.getLocations();
   }
 
-  metricFindApplications(start: number, end: number, limit = 0) {
-    return this.simpleRequest.getApplications(start, end, limit);
+  async metricFindApplications(start: number, end: number, limit = 0) {
+    return await this.simpleRequest.getApplications(start, end, limit);
   }
 
-  metricFindHosts(start: number, end: number, pattern: string | null = null, limit = 0) {
-    return this.simpleRequest.getHosts(start, end, pattern, limit);
+  async metricFindHosts(start: number, end: number, pattern: string | null = null, limit = 0) {
+    return await this.simpleRequest.getHosts(start, end, pattern, limit);
   }
 
-  metricFindConversations(start: number, end: number, application: string | null = null, 
+  async metricFindConversations(start: number, end: number, application: string | null = null,
     location: string | null = null, protocol: string | null = null, limit = 0) {
-    return this.simpleRequest.getConversations(start, end, application, location, protocol, limit);
+    return await this.simpleRequest.getConversations(start, end, application, location, protocol, limit);
   }
-  
 
-  metricFindExporterNodes(query?: any, filter?: string) {
+
+  async metricFindExporterNodes(query?: any, filter?: string) {
     let self = this;
-    return this.client.getExporters().then((exporters) => {
-      let results = [] as any[];
-      _.each(exporters, function (exporter) {
-        results.push({text: exporter.label, value: exporter.id, expandable: true});
-      });
-      return self.getFilteredNodes(results, filter);
+    const exporters = await this.client.getExporters();
+    let results = [] as any[];
+    _.each(exporters, function (exporter) {
+      results.push({ text: exporter.label, value: exporter.id, expandable: true });
     });
+    return await self.getFilteredNodes(results, filter);
   }
 
-  metricFindInterfacesOnExporterNode(query) {
-    return this.client.getExporter(query).then((exporter) => {
-      let results = [] as any[];
-      _.each(exporter.interfaces, function (iff) {
-        results.push({text: iff.name + "(" + iff.index + ")", value: iff.index, expandable: true});
-      });
-      return results;
+  async metricFindInterfacesOnExporterNode(query) {
+    const node = await this.simpleRequest.getNodeByIdOrFsFsId(query);
+    const exporter = await this.client.getExporter(node.id);
+    let results = [] as any[];
+    _.each(exporter.interfaces, function (iff) {
+      results.push({ text: iff.name + "(" + iff.index + ")", value: iff.index, expandable: true });
     });
+    return results;
   }
 
-  metricFindDscpOnExporterNodeAndInterface(node, iface, start, end) {
-    return this.client.getDscpValues(node,  iface, start, end).then(
-        values => dscpSelectOptions(values)
+  async metricFindDscpOnExporterNodeAndInterface(node, iface, start, end) {
+    return await this.client.getDscpValues(node, iface, start, end).then(
+      values => dscpSelectOptions(values)
     );
   }
 

--- a/src/datasources/flow-ds/datasource.ts
+++ b/src/datasources/flow-ds/datasource.ts
@@ -257,13 +257,13 @@ export class FlowDatasource {
 
     let locationsQuery = query.match(locations);
     if (locationsQuery) {
-      return this.metricFindLocations();
+      return await this.metricFindLocations();
     }
 
     let applicationsQuery = query.match(applications);
     if (applicationsQuery) {
       let limit = applicationsQuery.length > 1 && !isNaN(parseInt(applicationsQuery[1].trim(), 10)) ? parseInt(applicationsQuery[1].trim(), 10) : 0;
-      return this.metricFindApplications(start, end, limit);
+      return await this.metricFindApplications(start, end, limit);
     }
 
     let conversationsQuery = query.match(conversations);
@@ -273,22 +273,22 @@ export class FlowDatasource {
         //first argument should be application, then location, then protocol, and last limit which should be a number
         //when multiple args are passed assume last is limit
         if (args.length === 1 && !isNaN(parseInt(args[0], 10))) {
-          return this.metricFindConversations(start, end, null, null, null, parseInt(args[0], 10));
+          return await this.metricFindConversations(start, end, null, null, null, parseInt(args[0], 10));
         } else if (args.length === 1) {          
-          return this.metricFindConversations(start, end, args[0]);
+          return await this.metricFindConversations(start, end, args[0]);
         } else if (args.length === 2 && _.every(args, s => isNaN(parseInt(s, 10)))) {
-          return this.metricFindConversations(start, end, args[0], args[1] );
+          return await this.metricFindConversations(start, end, args[0], args[1] );
         } else if (args.length === 2 && !_.every(args, s => isNaN(parseInt(s, 10)))) {
-          return this.metricFindConversations(start, end, args[0], null, null, parseInt(args[1], 10) );
+          return await this.metricFindConversations(start, end, args[0], null, null, parseInt(args[1], 10) );
         } else if (args.length === 3 && _.every(args, s =>  isNaN(parseInt(s, 10)))) {
-          return this.metricFindConversations(start, end, args[0], args[1], args[2] );
+          return await this.metricFindConversations(start, end, args[0], args[1], args[2] );
         } else if (args.length === 3 && !_.every(args, s =>  isNaN(parseInt(s, 10)))) {
-          return this.metricFindConversations(start, end, args[0], args[1], null, parseInt(args[2], 10) );
+          return await this.metricFindConversations(start, end, args[0], args[1], null, parseInt(args[2], 10) );
         } else if (args.length === 4 && !_.every(args, s =>  isNaN(parseInt(s, 10)))) {
-          return this.metricFindConversations(start, end, args[0], args[1], args[2], parseInt(args[3], 10) );
+          return await this.metricFindConversations(start, end, args[0], args[1], args[2], parseInt(args[3], 10) );
         }
       }
-      return this.metricFindConversations(start, end);
+      return await this.metricFindConversations(start, end);
     }
 
     let hostsQuery = query.match(hosts);
@@ -296,14 +296,14 @@ export class FlowDatasource {
       let args = hostsQuery.length > 1 ? hostsQuery[1].split(',').map(v => v.trim()) : null;
       if (args) {
         if (args.length === 1 &&  !isNaN(parseInt(args[0], 10))) {
-          return this.metricFindHosts(start, end, null, parseInt(args[0], 10));
+          return await this.metricFindHosts(start, end, null, parseInt(args[0], 10));
         } else if (args.length === 1) {
-          return this.metricFindHosts(start, end, args[0]);
+          return await this.metricFindHosts(start, end, args[0]);
         } else if (args.length === 2 && !isNaN(parseInt(args[1], 10))) {
-          return this.metricFindHosts(start, end, args[0], parseInt(args[1], 10));
+          return await this.metricFindHosts(start, end, args[0], parseInt(args[1], 10));
         }
       }
-      return this.metricFindHosts(start, end);
+      return await this.metricFindHosts(start, end);
 
 
     }
@@ -311,17 +311,17 @@ export class FlowDatasource {
     let exporterNodesQuery = query.match(exporterNodesRegex);
     if (exporterNodesQuery) {
       let exporterNodesQueryFilter = exporterNodesQuery.length > 1 ? exporterNodesQuery[1] : null;
-      return this.metricFindExporterNodes(query, exporterNodesQueryFilter);
+      return await this.metricFindExporterNodes(query, exporterNodesQueryFilter);
     }
 
     let interfacesOnExporterNodeQuery = query.match(interfacesOnExporterNodeRegex);
     if (interfacesOnExporterNodeQuery) {
-      return this.metricFindInterfacesOnExporterNode(interfacesOnExporterNodeQuery[1]);
+      return await this.metricFindInterfacesOnExporterNode(interfacesOnExporterNodeQuery[1]);
     }
 
     let dscpOnExporterNodeAndInterfaceQuery = query.match(dscpOnExporterNodeAndInterfaceRegex);
     if (dscpOnExporterNodeAndInterfaceQuery) {
-      return this.metricFindDscpOnExporterNodeAndInterface(
+      return await this.metricFindDscpOnExporterNodeAndInterface(
           dscpOnExporterNodeAndInterfaceQuery[1], // node
           dscpOnExporterNodeAndInterfaceQuery[2], // interface
           dscpOnExporterNodeAndInterfaceQuery[3], // start millis
@@ -329,7 +329,7 @@ export class FlowDatasource {
       );
     }
 
-    return Promise.resolve([]);
+    return await Promise.resolve([]);
   }
 
   async metricFindLocations() {

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -512,6 +512,18 @@ export class SimpleOpenNMSRequest {
       return results;
     }
   }
+
+  async getNodeByIdOrFsFsId(query:string){
+    const response = await this.doOpenNMSRequest({
+      url: this.nodes + '/' + query.trim(),
+      method: 'GET',
+      params: {
+        limit: 0
+      }
+    })
+
+    return response.data;
+  }
 }
 
 

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -513,7 +513,7 @@ export class SimpleOpenNMSRequest {
     }
   }
 
-  async getNodeByIdOrFsFsId(query:string){
+  async getNodeByIdOrFsFsId(query: string){
     const response = await this.doOpenNMSRequest({
       url: this.nodes + '/' + query.trim(),
       method: 'GET',


### PR DESCRIPTION
fixed issue when passing FS:FSID instead of node id to flows Interface function interfacesOnExporterNodeWithFlows()

Refactored Promises to use async/await in flows datasource

* JIRA (Issue Tracker): http://issues.opennms.org/browse/HELM-336
* Continuous Integration: [CircleCI](https://circleci.com/gh/OpenNMS/opennms-helm)
