### PR TITLE
NMS-14666: Update all doc repos with link to new Antora UI bundle

### DIFF
--- a/site.yml
+++ b/site.yml
@@ -1,22 +1,22 @@
-site: 
+site:
   title: OpenNMS Helm Documentation
   url: https://opennms-helm-doc.netlify.com
   start_page: helm::index.adoc
-content: 
-  sources: 
+content:
+  sources:
   - url: https://github.com/OpenNMS/opennms-helm.git
     branches: HEAD
     tags: v*
     start_path: docs
 ui:
   bundle:
-    url: https://github.com/opennms-forge/antora-ui-opennms/releases/download/v1.0.1/ui-bundle.zip
+    url: https://github.com/opennms-forge/antora-ui-opennms/releases/download/v3.0.1/ui-bundle.zip
 asciidoc:
   attributes:
     stem: latexmath
-output: 
-  clean: true 
-  dir: ./public 
-  destinations: 
+output:
+  clean: true
+  dir: ./public
+  destinations
   - provider: fs
-  - provider: archive 
+  - provider: archive


### PR DESCRIPTION
NMS-14666: update all doc repos with link to new Antora UI bundle: updated the HLEM repo so that the site.yml file includes link to current Antora UI bundle.

# Pull Request Check Sheet

* [ ] Have you read and followed our [Contribution Guidelines](https://github.com/OpenNMS/opennms/blob/develop/CONTRIBUTING.md)?
* [ ] Have you [made an issue in the OpenNMS issue tracker](https://issues.opennms.org)?<br>If so, you should:
  1. update the title of this PR to be of the format: `${JIRA-ISSUE-NUMBER}: subject of pull request`
  2. update the JIRA link at the bottom of this comment to refer to the real issue number
  3. prefix your commit messages with the issue number, if possible
* [ ] Have you made a comment in that issue which points back to this PR?
* [ ] Have you updated the JIRA link at the bottom of this comment to link to your issue?
* [ ] If this is a new feature, is there documentation?
* [ ] If this is a new feature or substantial change, are there tests that cover it?

# Pull Request Process

One or more reviewers should be assigned to each PR.

If you know that a particular person is subject matter expert in the area your PR affects, feel free to assign one or more reviewers when you create this PR, otherwise reviewers will be assigned for you.

Once the reviewer(s) accept the PR and the branch passes continuous integration in Bamboo, the PR is eligible for merge.

At that time, if you have commit access (are an OpenNMS Group employee or a member of the Order of the Green Polo) you are welcome to merge the PR.
Otherwise, a reviewer can merge it for you.

Thanks for taking time to contribute!

# External References

* JIRA (Issue Tracker): http://issues.opennms.org/browse/NMS-14666
* Continuous Integration: [CircleCI](https://circleci.com/gh/OpenNMS/opennms-helm)
