### PR TITLE
HELM-337: exporterNodesWithFlows() query handles criteria differently than other queries

### DIFF
--- a/docs/modules/datasources/pages/entity_datasource.adoc
+++ b/docs/modules/datasources/pages/entity_datasource.adoc
@@ -41,13 +41,15 @@ Use this inside `nodeFilter()` to filter the number of nodes displayed by locati
 
 The `nodeFilter()` query returns a list of nodes which match the given filter expression.
 
-The filter expression must be an existing node attribute and its corresponding value. 
+The filter expression must be an existing node attribute and its corresponding value.
+Separate multiple filter expressions with an '&' (<attribute1>=<value1> & <attribute2>=<value2> & ...).
 The value can be a constant or a variable.
 
 Example:
 * nodeFilter(<node_attribute>='<value>')
 * nodeFilter(location='Default')
 * nodeFilter(location='$location')
+* nodeFilter(location='$location' & label='localhost')
 
 === nodes([attribute])
 

--- a/docs/modules/datasources/pages/flow_datasource.adoc
+++ b/docs/modules/datasources/pages/flow_datasource.adoc
@@ -57,7 +57,7 @@ exporterNodesWithFlows()
 ```
 
 The filter expression must be an existing node attribute and its corresponding value.
-Can accespt more than one filter expression separated by an '&' (<attribute1>=<value1> & <attribute2>=<value2> & ...)
+Separate multiple filter expressions with an '&' (<attribute1>=<value1> & <attribute2>=<value2> & ...).
 The value can be a constant, a variable, or a regular expression.
 
 .Example variable expression

--- a/docs/modules/datasources/pages/flow_datasource.adoc
+++ b/docs/modules/datasources/pages/flow_datasource.adoc
@@ -57,12 +57,15 @@ exporterNodesWithFlows()
 ```
 
 The filter expression must be an existing node attribute and its corresponding value.
-The value can be a constant or a variable.
+Can accespt more than one filter expression separated by an '&' (<attribute1>=<value1> & <attribute2>=<value2> & ...)
+The value can be a constant, a variable or a regular expression.
 
 .Example variable expression
 * exporterNodesWithFlows(<node_attribute>='<value>')
 * exporterNodesWithFlows(location='Default')
 * exporterNodesWithFlows(location='$location')
+* exporterNodesWithFlows(location='$location' & label='localhost')
+* exporterNodesWithFlows(location='$location' & label='.\*com.*')
 
 === interfacesOnExporterNodeWithFlows(<nodeCriteria>)
 

--- a/docs/modules/datasources/pages/flow_datasource.adoc
+++ b/docs/modules/datasources/pages/flow_datasource.adoc
@@ -58,7 +58,7 @@ exporterNodesWithFlows()
 
 The filter expression must be an existing node attribute and its corresponding value.
 Can accespt more than one filter expression separated by an '&' (<attribute1>=<value1> & <attribute2>=<value2> & ...)
-The value can be a constant, a variable or a regular expression.
+The value can be a constant, a variable, or a regular expression.
 
 .Example variable expression
 * exporterNodesWithFlows(<node_attribute>='<value>')

--- a/src/datasources/entity-ds/datasource.ts
+++ b/src/datasources/entity-ds/datasource.ts
@@ -420,10 +420,10 @@ export class OpenNMSEntityDatasource {
         let filter = new API.Filter();
 
         for (const pair of filtermap) {
-            const propertyKey = entity.getAttributeMapping().getApiAttribute(pair[0].trim());
-            const propertyValue = pair[1].trim().replace(/^["'](.+(?=["']$))["']$/, '$1');
+            const propertyKey = entity.getAttributeMapping().getApiAttribute(pair[0]);
+            const propertyValue = pair[1];
 
-            if (propertyValue.trim().startsWith('$')) {
+            if (propertyValue.startsWith('$')) {
                 const variableName = this.templateSrv.getVariableName(propertyValue);
                 const templateVariable = this._getTemplateVariable(variableName);
                 if (templateVariable && templateVariable.current.value) {

--- a/src/datasources/entity-ds/datasource.ts
+++ b/src/datasources/entity-ds/datasource.ts
@@ -11,7 +11,7 @@ import NodeEntity from './NodeEntity';
 import OutageEntity from './OutageEntity';
 import SnmpInterfaceEntity from './SnmpInterfaceEntity';
 import Entity from "./Entity";
-import { SimpleOpenNMSRequest } from "lib/utils";
+import { SimpleOpenNMSRequest, getNodeFilterMap } from "lib/utils";
 
 const isNumber = function isNumber(num) {
     return ((parseInt(num,10) + '') === (num + ''));
@@ -415,32 +415,29 @@ export class OpenNMSEntityDatasource {
         return this.simpleRequest.getLocations();
     }
 
-    metricFindNodeFilterQuery(entity, attribute) {
-        let propValuePair = attribute ? attribute.split('=') : null;
-        let filter = new API.Filter();        
+    async metricFindNodeFilterQuery(entity, attribute) {
+        const filtermap = getNodeFilterMap(attribute);
+        let filter = new API.Filter();
 
-        if (propValuePair && propValuePair.length === 2) {
-            const propertyKey =  entity.getAttributeMapping().getApiAttribute( propValuePair[0].trim());
-            const propertyValue = propValuePair[1].trim().replace(/^["'](.+(?=["']$))["']$/, '$1');
+        for (const pair of filtermap) {
+            const propertyKey = entity.getAttributeMapping().getApiAttribute(pair[0].trim());
+            const propertyValue = pair[1].trim().replace(/^["'](.+(?=["']$))["']$/, '$1');
+
             if (propertyValue.trim().startsWith('$')) {
-
                 const variableName = this.templateSrv.getVariableName(propertyValue);
                 const templateVariable = this._getTemplateVariable(variableName);
                 if (templateVariable && templateVariable.current.value) {
                     filter.withAndRestriction(new API.Restriction(propertyKey, API.Comparators.EQ, templateVariable.current.value));
-                    filter.limit = 0;
                 }
             } else if (propertyKey && propertyValue) {
                 filter.withAndRestriction(new API.Restriction(propertyKey, API.Comparators.EQ, propertyValue));
-                filter.limit = 0;
             }
         }
 
-        return this.opennmsClient.getNodeByFilter(filter)
-        .then(nodes => {
-            return nodes.map(node =>  {
-                return {id: node.id, label: node.id, text: node.id ? String(node.id) : node.id, value: node.id }
-            });
+        filter.limit = 0;
+        const nodes = await this.opennmsClient.getNodeByFilter(filter);
+        return nodes.map(node => {
+            return { id: node.id, label: node.id, text: node.id ? String(node.id) : node.id, value: node.id }
         });
     }
 

--- a/src/datasources/flow-ds/datasource.ts
+++ b/src/datasources/flow-ds/datasource.ts
@@ -11,7 +11,7 @@ import {
 
 import { ClientDelegate } from 'lib/client_delegate';
 import { dscpLabel, dscpSelectOptions } from 'lib/tos_helper';
-import { processSelectionVariables, swapColumns, SimpleOpenNMSRequest } from 'lib/utils';
+import { processSelectionVariables, swapColumns, SimpleOpenNMSRequest, getNodeFilterMap } from 'lib/utils';
 import { OnmsFlowTable } from 'opennms/src/model/OnmsFlowTable';
 import { OnmsFlowSeries } from 'opennms/src/model/OnmsFlowSeries';
 
@@ -608,22 +608,12 @@ export class FlowDatasource {
   }
 
   async getFilteredNodes(exporterNodes?: any[], filterParam?: string): Promise<any> {
-    const filters = filterParam ? filterParam.split('&') : [];
-    if (filters.length === 0) {
+    
+    let results: any[] = [];
+    const filtermap = getNodeFilterMap(filterParam);
+    if (filtermap.size === 0) {
       return await Promise.resolve(exporterNodes);
     }
-
-    let filtermap = new Map<string, string>();
-    let results: any[] = [];
-
-    filters.forEach((filter, index, arr) => {
-      let propValue = filter ? filter.split('=') : null;
-      if (propValue && propValue.length === 2) {
-        let propertyKey = propValue[0].trim();
-        let propertyValue = propValue[1].trim().replace(/^["'](.+(?=["']$))["']$/, '$1');
-        filtermap.set(propertyKey, propertyValue);
-      }
-    });
     if (exporterNodes) {
       for (const exportedNode of exporterNodes) {
         let matchAll = true;

--- a/src/datasources/flow-ds/datasource.ts
+++ b/src/datasources/flow-ds/datasource.ts
@@ -609,7 +609,7 @@ export class FlowDatasource {
 
   async getFilteredNodes(exporterNodes?: any[], filterParam?: string): Promise<any> {
     const filters = filterParam ? filterParam.split('&') : [];
-    if (filters.length == 0) {
+    if (filters.length === 0) {
       return await Promise.resolve(exporterNodes);
     }
 

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -514,5 +514,18 @@ export class SimpleOpenNMSRequest {
   }
 }
 
+export function getNodeFilterMap(filterParam?: string): Map<string, string>{
+  const filters = filterParam ? filterParam.split('&') : [];
+  let filtermap = new Map<string, string>(); 
+  filters.forEach((filter, index, arr) => {
+    let propValue = filter ? filter.split('=') : null;
+    if (propValue && propValue.length === 2) {
+      let propertyKey = propValue[0].trim();
+      let propertyValue = propValue[1].trim().replace(/^["'](.+(?=["']$))["']$/, '$1');
+      filtermap.set(propertyKey, propertyValue);
+    }
+  });
+  return filtermap;
+}
 
 


### PR DESCRIPTION
Allow multiple attribute/value pair filters and values also allow regular expressions
Flows DS
Example: exporterNodesWithFlows(location='$location' & label='.\*com.*')

Also allow multiple attribute/value filters for the nodeFilter function in Entities DS. This one doesn't accept Regex yet since that is done on the backend.
Entity DS now also would work with 
nodeFilterlocation='$location' & label='localhost')


# External References

* JIRA (Issue Tracker): http://issues.opennms.org/browse/HELM-337
* Continuous Integration: [CircleCI](https://circleci.com/gh/OpenNMS/opennms-helm)
