### PR TITLE
HELM-333: Flow Datasource Cannot Be Filtered By Interface Resource ID

### DIFF
--- a/src/datasources/flow-ds/datasource.ts
+++ b/src/datasources/flow-ds/datasource.ts
@@ -102,7 +102,7 @@ export class FlowDatasource {
     let includeOther = FlowDatasource.isFunctionPresent(query, 'includeOther');
     // Filter
     let exporterNode = this.getFunctionParameterOrDefault(query, 'withExporterNode', 0);
-    let ifIndex = await this.getIfIndexIfExistsFromInterface(exporterNode, this.getFunctionParameterOrDefault(query, 'withIfIndex', 0));
+    let ifIndex = await this.simpleRequest.getIfIndexFromSnmpResourceIfExixts(exporterNode, this.getFunctionParameterOrDefault(query, 'withIfIndex', 0));
     let dscp = processSelectionVariables(this.getFunctionParametersOrDefault(query, 'withDscp', 0, null));
     let applications = processSelectionVariables(this.getFunctionParametersOrDefault(query, 'withApplication', 0, null));
     let conversations = processSelectionVariables(this.getFunctionParametersOrDefault(query, 'withConversation', 0, null));
@@ -158,7 +158,7 @@ export class FlowDatasource {
     let includeOther = FlowDatasource.isFunctionPresent(query, 'includeOther');
     // Filter
     let exporterNode = this.getFunctionParameterOrDefault(query, 'withExporterNode', 0);
-    let ifIndex = await this.getIfIndexIfExistsFromInterface(exporterNode, this.getFunctionParameterOrDefault(query, 'withIfIndex', 0));
+    let ifIndex = await this.simpleRequest.getIfIndexFromSnmpResourceIfExixts(exporterNode, this.getFunctionParameterOrDefault(query, 'withIfIndex', 0));
     let dscp = processSelectionVariables(this.getFunctionParametersOrDefault(query, 'withDscp', 0, null));
     let applications = processSelectionVariables(this.getFunctionParametersOrDefault(query, 'withApplication', 0, null));
     let conversations = processSelectionVariables(this.getFunctionParametersOrDefault(query, 'withConversation', 0, null));
@@ -632,16 +632,5 @@ export class FlowDatasource {
       });
     } else { return Promise.resolve(exporterNodes); }
   }
-
-  async getIfIndexIfExistsFromInterface(nodeId: number | string, iface: any) {
-    if (isNaN(iface) && typeof iface === 'string') {
-      const ifIndex = await this.simpleRequest.getInterfaceIfIndexByName(nodeId, iface);
-      if (!ifIndex) {
-        throw new Error('Could not find ifIndex from ifName: ' + iface);
-      } else {
-        return ifIndex;
-      }
-    } else return iface;
-  }
-
 }
+

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -361,6 +361,7 @@ export class SimpleOpenNMSRequest {
   readonly flows = "/rest/flows";
   readonly locations = "/rest/monitoringLocations";
   readonly nodes = "/rest/nodes"
+  readonly interfaces = "/api/v2/snmpinterfaces";
 
   constructor(backendSrv, url) {
     this.backendSrv = backendSrv;
@@ -511,6 +512,31 @@ export class SimpleOpenNMSRequest {
       });
       return results;
     }
+  }
+
+  async getNodeByIdOrFsFsId(query: string){
+    const response = await this.doOpenNMSRequest({
+      url: this.nodes + '/' + query.trim(),
+      method: 'GET',
+      params: {
+        limit: 0
+      }
+    })
+
+    return response.data;
+  }
+
+  async getInterfaceIfIndexByName(nodeId: string | number, ifName: string){
+    const node = this.getNodeByIdOrFsFsId(nodeId.toString());
+    const response = await this.doOpenNMSRequest({
+      url: this.interfaces + '/_s=node.id==' + node.toString().trim() + ';ifName==' + ifName.trim(),
+      method: 'GET',
+      params: {
+        limit: 0
+      }
+    })
+
+    return response.ifIndex;
   }
 }
 

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -460,7 +460,7 @@ export class SimpleOpenNMSRequest {
   }
 
   async getHosts(start: number, end: number, pattern: string | null, limit = 0) {
-    if (!pattern) {
+    if(!pattern){
       pattern = ".*"
     }
 


### PR DESCRIPTION
Added funtionality to retrieve ifIndex from rest/resources response and use it in flows withIfIndex filter.

* JIRA (Issue Tracker): http://issues.opennms.org/browse/HELM-333
* Continuous Integration: [CircleCI](https://circleci.com/gh/OpenNMS/opennms-helm)
