### PR TITLE
HELM-354: Entity DS React updates, get metricFindQuery and template variables working

### DIFF
--- a/src/datasources/entity-ds-react/EntityHelper.tsx
+++ b/src/datasources/entity-ds-react/EntityHelper.tsx
@@ -72,17 +72,17 @@ export const getPropertyComparators = (entityName: string, propertyId: string, c
         case EntityTypes.Alarms:
             return client.getAlarmPropertyComparators(propertyId)
         case EntityTypes.Nodes:
-            return client.getNodeProperties()
+            return client.getNodePropertyComparators(propertyId)
         case EntityTypes.IPInterfaces:
-            return client.getIpInterfaceProperties()
+            return client.getIpInterfacePropertyComparators(propertyId)
         case EntityTypes.SNMPInterfaces:
-            return client.getSnmpInterfaceProperties()
+            return client.getSnmpInterfacePropertyComparators(propertyId)
         case EntityTypes.MonitoredServices:
-            return client.getMonitoredServiceProperties()
+            return client.getMonitoredServicePropertyComparators(propertyId)
         case EntityTypes.Outages:
-            return client.getOutageProperties()
+            return client.getOutagePropertyComparators(propertyId)
         default:
-            return Promise.resolve([] as API.SearchProperty[])
+            return Promise.resolve([] as API.Comparator[])
     }
 }
 

--- a/src/datasources/entity-ds-react/queries/attributeMappings.ts
+++ b/src/datasources/entity-ds-react/queries/attributeMappings.ts
@@ -1,0 +1,81 @@
+import { EntityTypes } from '../constants'
+
+/**
+ * Given an entity type and query or query attribute, return the DAO mapping for that attribute, or
+ * the original query/attribute if there is no special mapping.
+ */
+export const getAttributeMapping = (entityType: string, attribute: string): string => {
+    const attributeMap = getAttributeMap(entityType)
+
+    return attributeMap[attribute] || attribute
+}
+
+const getAttributeMap = (entityType: string) => {
+    switch (entityType) {
+        case EntityTypes.Alarms:
+            return alarmAttributeMapping
+        case EntityTypes.Nodes:
+            return nodeAttributeMapping
+        case EntityTypes.IPInterfaces:
+            return ipInterfaceAttributeMapping
+        case EntityTypes.SNMPInterfaces:
+            return snmpInterfaceAttributeMapping
+        case EntityTypes.MonitoredServices:
+            return monitoredServiceAttributeMapping
+        case EntityTypes.Outages:
+            return outageAttributeMapping
+        default:
+            return {}
+    }
+}
+
+const nodeAttributeMapping = {
+  category: 'category.name',
+  categories: 'category.name',
+  'categories.name': 'category.name',
+  ifIndex: 'snmpInterface.ifIndex',
+  ipAddr: 'ipInterface.ipAddress',
+  ipAddress: 'ipInterface.ipAddress',
+  ipHostname: 'ipInterface.ipHostname',
+  location: 'location.locationName',
+  parentId: 'parent.id',
+  parentForeignSource: 'parent.foreignSource',
+  // typo??
+  //parentForeignId: 'parent.foreindId',
+  parentForeignId: 'parent.foreignId',
+}
+
+const alarmAttributeMapping = {
+  'location': 'location.locationName',
+  'service': 'serviceType.name',
+  'category': 'category.name',
+  'ipAddr': 'ipInterface.ipAddress',
+  'ipAddress': 'ipInterface.ipAddress',
+  'lastEvent.severity': 'lastEvent.severity.label',
+  'severity': 'severity',
+  'troubleTicketState': 'troubleTicketState.label',
+}
+
+const ipInterfaceAttributeMapping = {
+  ifAlias: 'snmpInterface.ifAlias',
+  ifDescr: 'snmpInterface.ifDescr',
+  ifIndex: 'snmpInterface.ifIndex',
+  ifName: 'snmpInterface.ifName',
+  physAddr: 'snmpInterface.physAddr',
+}
+
+const snmpInterfaceAttributeMapping = {}
+
+const monitoredServiceAttributeMapping = {
+  node: 'node.id',
+  nodeLabel: 'node.label',
+  foreignSource: 'node.foreignSource',
+  foreignId: 'node.foreignId',
+  ipAddress: 'ipInterface.ipAddress',
+}
+
+const outageAttributeMapping = {
+  // typo??
+  rode: 'nodeId',
+  node: 'nodeId',
+}

--- a/src/datasources/entity-ds-react/queries/index.ts
+++ b/src/datasources/entity-ds-react/queries/index.ts
@@ -1,1 +1,6 @@
+export * from './queryAlarms'
+export * from './queryIPInterfaces'
+export * from './queryMonitoredServices'
 export * from './queryNodes'
+export * from './queryOutages'
+export * from './querySNMPInterfaces'

--- a/src/datasources/entity-ds-react/queries/queryAlarms.ts
+++ b/src/datasources/entity-ds-react/queries/queryAlarms.ts
@@ -1,64 +1,68 @@
+import { OnmsColumn, OnmsTableData } from '../types'
 import { ClientDelegate } from "lib/client_delegate";
 import { OnmsAlarm } from "opennms/src/model/OnmsAlarm";
 import { API } from 'opennms'
 
-export const queryAlarms = async (client: ClientDelegate, filter: API.Filter) => {
+const columns = Object.freeze([
+    { text: 'ID', resource: 'id' },
+    { text: 'Count', resource: 'count' },
+    { text: 'Acked By', resource: 'ackUser' },
+    { text: 'Ack Time', resource: 'alarmAckTime', featured: true },
+    { text: 'UEI', resource: 'uei', featured: true },
+    { text: 'Severity', resource: 'severity', featured: true },
+    { text: 'Type', resource: 'type.label' },
+    { text: 'Description', resource: 'description' },
+    { text: 'Location', resource: 'location', featured: true },
+    { text: 'Log Message', resource: 'logMessage' },
+    { text: 'Reduction Key', resource: 'reductionKey', featured: true },
+    { text: 'Trouble Ticket', resource: 'troubleTicket' },
+    { text: 'Trouble Ticket State', resource: 'troubleTicketState.label' },
+    { text: 'Node ID', resource: 'node', featured: true },
+    { text: 'Node Label', resource: 'node.label', featured: true },
+    { text: 'Service', resource: 'service.name', featured: true },
+    { text: 'Suppressed Time', resource: 'suppressedTime' },
+    { text: 'Suppressed Until', resource: 'suppressedUntil' },
+    { text: 'Suppressed By', resource: 'suppressedBy' },
+    { text: 'IP Address', resource: 'ipAddress', featured: true },
+    { text: 'Is Acknowledged', resource: 'isAcknowledged', featured: true },
+    { text: 'First Event Time', resource: 'firstEventTime' },
+    { text: 'Last Event ID', resource: 'lastEvent.id' },
+    { text: 'Last Event Time', resource: 'lastEvent.time' },
+    { text: 'Last Event Source', resource: 'lastEvent.source' },
+    { text: 'Last Event Creation Time', resource: 'lastEvent.createTime' },
+    { text: 'Last Event Severity', resource: 'lastEvent.severity' },
+    { text: 'Last Event Label', resource: 'lastEvent.label' },
+    { text: 'Last Event Location', resource: 'lastEvent.location' },
+    { text: 'Sticky ID', resource: 'sticky.id' },
+    { text: 'Sticky Note', resource: 'sticky.body' },
+    { text: 'Sticky Author', resource: 'sticky.author' },
+    { text: 'Sticky Update Time', resource: 'sticky.updated' },
+    { text: 'Sticky Creation Time', resource: 'sticky.created' },
+    { text: 'Journal ID', resource: 'journal.id' },
+    { text: 'Journal Note', resource: 'journal.body' },
+    { text: 'Journal Author', resource: 'journal.author' },
+    { text: 'Journal Update Time', resource: 'journal.updated' },
+    { text: 'Journal Creation Time', resource: 'journal.created' },
+    { text: 'Is Situation', resource: 'isSituation', featured: true },
+    { text: 'Is In Situation', resource: 'isInSituation', featured: true, visible: false },
+    { text: 'Situation Alarm Count', resource: 'situationAlarmCount', featured: true },
+    { text: 'Affected Node Count', resource: 'affectedNodeCount', featured: true },
+    { text: 'Managed Object Instance', resource: 'managedObjectInstance' },
+    { text: 'Managed Object Type', resource: 'managedObjectType' },
+    { text: 'Categories', resource: 'category', featured: true, visible: false },
+    { text: 'Data Source' }
+] as OnmsColumn[]);
 
+export const getAlarmColumns = () => columns
+
+export const queryAlarms = async (client: ClientDelegate, filter: API.Filter): Promise<OnmsTableData> => {
     let alarms: OnmsAlarm[] = [];
+
     try {
         alarms = await client.findAlarms(filter)
     } catch (e) {
         console.error(e);
     }
-    const columns = [
-        { text: 'ID', resource: 'id' },
-        { text: 'Count', resource: 'count' },
-        { text: 'Acked By', resource: 'ackUser' },
-        { text: 'Ack Time', resource: 'alarmAckTime', featured: true },
-        { text: 'UEI', resource: 'uei', featured: true },
-        { text: 'Severity', resource: 'severity', featured: true },
-        { text: 'Type', resource: 'type.label' },
-        { text: 'Description', resource: 'description' },
-        { text: 'Location', resource: 'location', featured: true },
-        { text: 'Log Message', resource: 'logMessage' },
-        { text: 'Reduction Key', resource: 'reductionKey', featured: true },
-        { text: 'Trouble Ticket', resource: 'troubleTicket' },
-        { text: 'Trouble Ticket State', resource: 'troubleTicketState.label' },
-        { text: 'Node ID', resource: 'node', featured: true },
-        { text: 'Node Label', resource: 'node.label', featured: true },
-        { text: 'Service', resource: 'service.name', featured: true },
-        { text: 'Suppressed Time', resource: 'suppressedTime' },
-        { text: 'Suppressed Until', resource: 'suppressedUntil' },
-        { text: 'Suppressed By', resource: 'suppressedBy' },
-        { text: 'IP Address', resource: 'ipAddress', featured: true },
-        { text: 'Is Acknowledged', resource: 'isAcknowledged', featured: true },
-        { text: 'First Event Time', resource: 'firstEventTime' },
-        { text: 'Last Event ID', resource: 'lastEvent.id' },
-        { text: 'Last Event Time', resource: 'lastEvent.time' },
-        { text: 'Last Event Source', resource: 'lastEvent.source' },
-        { text: 'Last Event Creation Time', resource: 'lastEvent.createTime' },
-        { text: 'Last Event Severity', resource: 'lastEvent.severity' },
-        { text: 'Last Event Label', resource: 'lastEvent.label' },
-        { text: 'Last Event Location', resource: 'lastEvent.location' },
-        { text: 'Sticky ID', resource: 'sticky.id' },
-        { text: 'Sticky Note', resource: 'sticky.body' },
-        { text: 'Sticky Author', resource: 'sticky.author' },
-        { text: 'Sticky Update Time', resource: 'sticky.updated' },
-        { text: 'Sticky Creation Time', resource: 'sticky.created' },
-        { text: 'Journal ID', resource: 'journal.id' },
-        { text: 'Journal Note', resource: 'journal.body' },
-        { text: 'Journal Author', resource: 'journal.author' },
-        { text: 'Journal Update Time', resource: 'journal.updated' },
-        { text: 'Journal Creation Time', resource: 'journal.created' },
-        { text: 'Is Situation', resource: 'isSituation', featured: true },
-        { text: 'Is In Situation', resource: 'isInSituation', featured: true, visible: false },
-        { text: 'Situation Alarm Count', resource: 'situationAlarmCount', featured: true },
-        { text: 'Affected Node Count', resource: 'affectedNodeCount', featured: true },
-        { text: 'Managed Object Instance', resource: 'managedObjectInstance' },
-        { text: 'Managed Object Type', resource: 'managedObjectType' },
-        { text: 'Categories', resource: 'category', featured: true, visible: false },
-        { text: 'Data Source' }
-    ];
     const rows = alarms?.map((alarm) => {
         let row = [
             alarm.id,
@@ -118,11 +122,14 @@ export const queryAlarms = async (client: ClientDelegate, filter: API.Filter) =>
             // Data Source
             self.name
         ];
+
         return row;
     });
+
     return {
-        'columns': columns.filter(column => column.visible !== false),
-        'rows': rows,
-        'type': 'table',
-    }
+        name: 'alarms',
+        columns: columns.filter(column => column.visible !== false),
+        rows: rows,
+        type: 'table',
+    } as OnmsTableData
 }

--- a/src/datasources/entity-ds-react/queries/queryIPInterfaces.ts
+++ b/src/datasources/entity-ds-react/queries/queryIPInterfaces.ts
@@ -1,8 +1,28 @@
+import { OnmsColumn, OnmsTableData } from '../types'
 import { ClientDelegate } from "lib/client_delegate";
 import { OnmsIpInterface } from "opennms/src/model/OnmsIpInterface";
 import { API } from 'opennms'
 
-export const queryIPInterfaces = async (client: ClientDelegate, filter: API.Filter) => {
+const columns = Object.freeze([
+    { text: 'ID', resource: 'id' },
+    { text: 'IP Address', resource: 'ipAddress', featured: true, },
+    { text: 'Hostname', resource: 'hostname', featured: true, },
+    { text: 'Is Down?', resource: 'isDown', },
+    { text: 'Is Managed?', resource: 'isManaged', },
+    { text: 'Last Capsd Poll', resource: 'lastCapsdPoll', },
+    { text: 'Last Ingress Flow', resource: 'lastIngressFlow', },
+    { text: 'Last Egress Flow', resource: 'lastEgressFlow', },
+    { text: 'Service Count', resource: 'monitoredServiceCount', },
+    { text: 'SNMP Primary', resource: 'snmpPrimary', featured: true, },
+    { text: 'SNMP ifAlias', resource: 'snmpInterface.ifAlias' },
+    { text: 'SNMP ifDescr', resource: 'snmpInterface.ifDescr' },
+    { text: 'SNMP ifIndex', resource: 'snmpInterface.ifIndex' },
+    { text: 'SNMP PhysAddr', resource: 'snmpInterface.physAddr' },
+] as OnmsColumn[]);
+
+export const getIPInterfaceColumns = () => columns
+
+export const queryIPInterfaces = async (client: ClientDelegate, filter: API.Filter): Promise<OnmsTableData> => {
     let ifaces: OnmsIpInterface[] = [];
  
     try {
@@ -10,23 +30,6 @@ export const queryIPInterfaces = async (client: ClientDelegate, filter: API.Filt
     } catch (e) {
         console.error(e);
     }
-
-    const columns = [
-        { text: 'ID', resource: 'id' },
-        { text: 'IP Address', resource: 'ipAddress', featured: true, },
-        { text: 'Hostname', resource: 'hostname', featured: true, },
-        { text: 'Is Down?', resource: 'isDown', },
-        { text: 'Is Managed?', resource: 'isManaged', },
-        { text: 'Last Capsd Poll', resource: 'lastCapsdPoll', },
-        { text: 'Last Ingress Flow', resource: 'lastIngressFlow', },
-        { text: 'Last Egress Flow', resource: 'lastEgressFlow', },
-        { text: 'Service Count', resource: 'monitoredServiceCount', },
-        { text: 'SNMP Primary', resource: 'snmpPrimary', featured: true, },
-        { text: 'SNMP ifAlias', resource: 'snmpInterface.ifAlias' },
-        { text: 'SNMP ifDescr', resource: 'snmpInterface.ifDescr' },
-        { text: 'SNMP ifIndex', resource: 'snmpInterface.ifIndex' },
-        { text: 'SNMP PhysAddr', resource: 'snmpInterface.physAddr' },
-    ];
 
     const rows = ifaces?.map((iface: OnmsIpInterface) => {
         return [
@@ -48,8 +51,9 @@ export const queryIPInterfaces = async (client: ClientDelegate, filter: API.Filt
     });
 
     return {
-        'columns': columns,
-        'rows': rows,
-        'type': 'table',
-    }
+        name: 'ipInterfaces',
+        columns: columns,
+        rows: rows,
+        type: 'table',
+    } as OnmsTableData
 }

--- a/src/datasources/entity-ds-react/queries/queryMonitoredServices.ts
+++ b/src/datasources/entity-ds-react/queries/queryMonitoredServices.ts
@@ -1,9 +1,22 @@
+import { OnmsColumn, OnmsTableData } from '../types'
 import { ClientDelegate } from "lib/client_delegate";
 import { OnmsMonitoredService } from "opennms/src/model/OnmsMonitoredService";
 import { API } from 'opennms'
 
-export const queryMonitoredServices = async (client: ClientDelegate, filter: API.Filter) => {
+const columns = Object.freeze([
+    { text: 'ID', resource: 'id' },
+    { text: 'Last Failed Poll', resource: 'lastFail' },
+    { text: 'Last Good Poll', resource: 'lastGood' },
+    { text: 'IP Address', resource: 'ipInterface.ipAddress', featured: true },
+    { text: 'Type', resource: 'type.name', featured: true },
+    { text: 'Status', resource: 'status.id', featured: true }
+] as OnmsColumn[]);
+
+export const getMonitoredServicesColumns = () => columns
+
+export const queryMonitoredServices = async (client: ClientDelegate, filter: API.Filter): Promise<OnmsTableData> => {
     let services: OnmsMonitoredService[] = [];
+
     try {
         services = await client.findMonitoredServices(filter);
     } catch (e) {
@@ -11,7 +24,6 @@ export const queryMonitoredServices = async (client: ClientDelegate, filter: API
     }
 
     const rows = services?.map((service: OnmsMonitoredService) => {
-
         return [
             service.id,
             service.lastFail,
@@ -21,17 +33,11 @@ export const queryMonitoredServices = async (client: ClientDelegate, filter: API
             service.status?.toDisplayString(),
         ];
     });
-    const columns = [
-        { text: 'ID', resource: 'id' },
-        { text: 'Last Failed Poll', resource: 'lastFail' },
-        { text: 'Last Good Poll', resource: 'lastGood' },
-        { text: 'IP Address', resource: 'ipInterface.ipAddress', featured: true },
-        { text: 'Type', resource: 'type.name', featured: true },
-        { text: 'Status', resource: 'status.id', featured: true },
-    ];
+
     return {
-        'columns': columns,
-        'rows': rows,
-        'type': 'table',
-    }
+        name: 'monitoredServices',
+        columns: columns,
+        rows: rows,
+        type: 'table',
+    } as OnmsTableData
 }

--- a/src/datasources/entity-ds-react/queries/queryNodes.ts
+++ b/src/datasources/entity-ds-react/queries/queryNodes.ts
@@ -1,42 +1,47 @@
 import { ClientDelegate } from "lib/client_delegate";
 import { OnmsNode } from "opennms/src/model/OnmsNode";
 import { API } from 'opennms'
+import { OnmsColumn, OnmsTableData } from '../types'
 
-export const queryNodes = async (client: ClientDelegate, filter: API.Filter) => {
+const columns = Object.freeze([
+    { text: 'ID', resource: 'id' },
+    { text: 'Label', resource: 'label', featured: true, },
+    { text: 'Label Source', resource: 'labelSource' },
+    { text: 'Foreign Source', resource: 'foreignSource', featured: true, },
+    { text: 'Foreign ID', resource: 'foreignId', featured: true, },
+    { text: 'Location', resource: 'location.locationName' },
+    { text: 'Creation Time', resource: 'createTime', featured: true, },
+    { text: 'Parent ID', resource: 'parent.id' },
+    { text: 'Parent Foreign Source', resource: 'parent.foreignSource' },
+    { text: 'Parent Foreign ID', resource: 'parent.foreignId' },
+    { text: 'Type', resource: 'type' },
+    { text: 'SNMP sysObjectID', resource: 'sysObjectId' },
+    { text: 'SNMP sysName', resource: 'sysName' },
+    { text: 'SNMP sysDescription', resource: 'sysDescription' },
+    { text: 'SNMP sysLocation', resource: 'sysLocation' },
+    { text: 'SNMP sysContact', resource: 'sysContact' },
+    { text: 'NETBIOS/SMB Name', resource: 'netBiosName' },
+    { text: 'NETBIOS/SMB Domain', resource: 'netBiosDomain' },
+    { text: 'Operating System', resource: 'operatingSystem' },
+    { text: 'Last Poll Time', resource: 'lastCapsdPoll' },
+    /* { text: 'Primary SNMP Physical Address', resource: 'ipInterface.snmpInterface.physAddr' }, */
+    { text: 'Primary SNMP ifIndex', resource: 'snmpInterface.ifIndex' },
+    { text: 'Primary IP Interface', resource: 'ipInterface.ipAddress' },
+    /* { text: 'Primary IP Hostname', resource: 'ipInterface.ipHostname' }, */
+    { text: 'Categories', resource: 'category.name', featured: true, },
+    { text: 'Data Source' }
+] as OnmsColumn[])
+
+export const getNodeColumns = () => columns
+
+export const queryNodes = async (client: ClientDelegate, filter: API.Filter): Promise<OnmsTableData> => {
     let nodes: OnmsNode[] = [];
+
     try {
         nodes = await client.findNodes(filter, true)
     } catch (e) {
         console.error(e);
     }
-    const columns = [
-        { text: 'ID', resource: 'id' },
-        { text: 'Label', resource: 'label', featured: true, },
-        { text: 'Label Source', resource: 'labelSource' },
-        { text: 'Foreign Source', resource: 'foreignSource', featured: true, },
-        { text: 'Foreign ID', resource: 'foreignId', featured: true, },
-        { text: 'Location', resource: 'location.locationName' },
-        { text: 'Creation Time', resource: 'createTime', featured: true, },
-        { text: 'Parent ID', resource: 'parent.id' },
-        { text: 'Parent Foreign Source', resource: 'parent.foreignSource' },
-        { text: 'Parent Foreign ID', resource: 'parent.foreignId' },
-        { text: 'Type', resource: 'type' },
-        { text: 'SNMP sysObjectID', resource: 'sysObjectId' },
-        { text: 'SNMP sysName', resource: 'sysName' },
-        { text: 'SNMP sysDescription', resource: 'sysDescription' },
-        { text: 'SNMP sysLocation', resource: 'sysLocation' },
-        { text: 'SNMP sysContact', resource: 'sysContact' },
-        { text: 'NETBIOS/SMB Name', resource: 'netBiosName' },
-        { text: 'NETBIOS/SMB Domain', resource: 'netBiosDomain' },
-        { text: 'Operating System', resource: 'operatingSystem' },
-        { text: 'Last Poll Time', resource: 'lastCapsdPoll' },
-        /* { text: 'Primary SNMP Physical Address', resource: 'ipInterface.snmpInterface.physAddr' }, */
-        { text: 'Primary SNMP ifIndex', resource: 'snmpInterface.ifIndex' },
-        { text: 'Primary IP Interface', resource: 'ipInterface.ipAddress' },
-        /* { text: 'Primary IP Hostname', resource: 'ipInterface.ipHostname' }, */
-        { text: 'Categories', resource: 'category.name', featured: true, },
-        { text: 'Data Source' }
-    ];
     const rows = nodes?.map((node) => {
         return [
             node.id,
@@ -64,8 +69,9 @@ export const queryNodes = async (client: ClientDelegate, filter: API.Filter) => 
     })
   
     return {
-        'columns': columns,
-        'rows': rows,
-        'type': 'table',
-    }
+        name: 'nodes',
+        columns: columns,
+        rows: rows,
+        type: 'table',
+    } as OnmsTableData
 }

--- a/src/datasources/entity-ds-react/queries/queryOutages.ts
+++ b/src/datasources/entity-ds-react/queries/queryOutages.ts
@@ -1,31 +1,34 @@
-
+import { OnmsColumn, OnmsTableData } from '../types'
 import { ClientDelegate } from "lib/client_delegate";
 import { OnmsOutage } from "opennms/src/model/OnmsOutage";
 import { API } from 'opennms'
 
-export const queryOutages = async (client: ClientDelegate, filter: API.Filter) => {
+const columns = Object.freeze([
+    { text: 'ID', resource: 'id' },
+    { text: 'Foreign Source', resource: 'foreignSource', featured: true },
+    { text: 'Foreign ID', resource: 'foreignId' },
+    { text: 'Node ID', resource: 'nodeId' },
+    { text: 'Node Label', resource: 'nodeLabel', featured: true },
+    { text: 'IP Address', resource: 'ipAddress', featured: true },
+    { text: 'Service', resource: 'monitoredService.type.name', featured: true },
+    { text: 'Lost Service', resource: 'ifLostService', featured: true },
+    { text: 'Regained Service', resource: 'ifRegainedService', featured: true },
+    { text: 'Suppressed', resource: 'suppressTime' },
+    { text: 'Suppressed By', resource: 'suppressedBy' },
+    { text: 'Perspective', resource: 'perspective', featured: true },
+] as OnmsColumn[]);
+
+export const getOutageColumns = () => columns
+
+export const queryOutages = async (client: ClientDelegate, filter: API.Filter): Promise<OnmsTableData> => {
     let outages: OnmsOutage[] = [];
     try {
         outages = await client.findOutages(filter);
     } catch (e) {
         console.error(e);
     }
-    const columns = [
-        { text: 'ID', resource: 'id' },
-        { text: 'Foreign Source', resource: 'foreignSource', featured: true },
-        { text: 'Foreign ID', resource: 'foreignId' },
-        { text: 'Node ID', resource: 'nodeId' },
-        { text: 'Node Label', resource: 'nodeLabel', featured: true },
-        { text: 'IP Address', resource: 'ipAddress', featured: true },
-        { text: 'Service', resource: 'monitoredService.type.name', featured: true },
-        { text: 'Lost Service', resource: 'ifLostService', featured: true },
-        { text: 'Regained Service', resource: 'ifRegainedService', featured: true },
-        { text: 'Suppressed', resource: 'suppressTime' },
-        { text: 'Suppressed By', resource: 'suppressedBy' },
-        { text: 'Perspective', resource: 'perspective', featured: true },
-    ];
-    const rows = outages?.map((outage: OnmsOutage) => {
 
+    const rows = outages?.map((outage: OnmsOutage) => {
         return [
             outage.id,
             outage.foreignSource,
@@ -41,9 +44,11 @@ export const queryOutages = async (client: ClientDelegate, filter: API.Filter) =
             outage.perspective,
         ];
     });
+
     return {
-        'columns': columns,
-        'rows': rows,
-        'type': 'table',
-    }
+        name: 'outages',
+        columns: columns,
+        rows: rows,
+        type: 'table',
+    } as OnmsTableData
 }

--- a/src/datasources/entity-ds-react/queries/querySNMPInterfaces.ts
+++ b/src/datasources/entity-ds-react/queries/querySNMPInterfaces.ts
@@ -1,9 +1,28 @@
-
+import { OnmsColumn, OnmsTableData } from '../types'
 import { OnmsSnmpInterface } from "opennms/src/model/OnmsSnmpInterface";
 import { ClientDelegate } from "lib/client_delegate";
 import { API } from 'opennms'
 
-export const querySNMPInterfaces = async (client: ClientDelegate, filter: API.Filter) => {
+const columns = Object.freeze([
+    { text: 'ID', resource: 'id' },
+    { text: 'Index', resource: 'ifIndex' },
+    { text: 'Description', resource: 'ifDescr', featured: true },
+    { text: 'Type', resource: 'ifType' },
+    { text: 'Name', resource: 'ifName', featured: true },
+    { text: 'Speed', resource: 'ifSpeed', featured: true },
+    { text: 'Admin Status', resource: 'ifAdminStatus' },
+    { text: 'Operational Status', resource: 'ifOperStatus' },
+    { text: 'Alias', resource: 'ifAlias', featured: true },
+    { text: 'Last Capsd Poll', resource: 'lastCapsdPoll' },
+    { text: 'Collected?', resource: 'collect' },
+    { text: 'Polled?', resource: 'poll' },
+    { text: 'Last SNMP Poll', resource: 'lastSnmpPoll' },
+    { text: 'Physical Address', resource: 'physAddr' }
+] as OnmsColumn[]);
+
+export const getSNMPInterfaceColumns = () => columns
+
+export const querySNMPInterfaces = async (client: ClientDelegate, filter: API.Filter): Promise<OnmsTableData> => {
     let ifaces: OnmsSnmpInterface[] = [];
 
     try {
@@ -11,23 +30,6 @@ export const querySNMPInterfaces = async (client: ClientDelegate, filter: API.Fi
     } catch (e) {
         console.error(e);
     }
-
-    const columns = [
-        { text: 'ID', resource: 'id' },
-        { text: 'Index', resource: 'ifIndex' },
-        { text: 'Description', resource: 'ifDescr', featured: true },
-        { text: 'Type', resource: 'ifType' },
-        { text: 'Name', resource: 'ifName', featured: true },
-        { text: 'Speed', resource: 'ifSpeed', featured: true },
-        { text: 'Admin Status', resource: 'ifAdminStatus' },
-        { text: 'Operational Status', resource: 'ifOperStatus' },
-        { text: 'Alias', resource: 'ifAlias', featured: true },
-        { text: 'Last Capsd Poll', resource: 'lastCapsdPoll' },
-        { text: 'Collected?', resource: 'collect' },
-        { text: 'Polled?', resource: 'poll' },
-        { text: 'Last SNMP Poll', resource: 'lastSnmpPoll' },
-        { text: 'Physical Address', resource: 'physAddr' },
-    ];
 
     const rows = ifaces?.map((iface: OnmsSnmpInterface) => {
         return [
@@ -47,9 +49,11 @@ export const querySNMPInterfaces = async (client: ClientDelegate, filter: API.Fi
             iface.physAddr?.toString(),
         ];
     });
+
     return {
-        'columns': columns,
-        'rows': rows,
-        'type': 'table',
-    }
+        name: 'snmpInterfaces',
+        columns: columns,
+        rows: rows,
+        type: 'table',
+    } as OnmsTableData
 }

--- a/src/datasources/entity-ds-react/types.ts
+++ b/src/datasources/entity-ds-react/types.ts
@@ -1,4 +1,13 @@
-import { DataQuery, DataQueryRequest, DataSourceJsonData, SelectableValue, QueryEditorProps } from "@grafana/data";
+import { API } from 'opennms'
+import {
+  Column,
+  DataQuery,
+  DataQueryRequest,
+  DataSourceJsonData,
+  SelectableValue,
+  QueryEditorProps,
+  TableData
+} from "@grafana/data";
 import { EntityDataSource } from "./EntityDataSource";
 
 /**
@@ -12,7 +21,7 @@ export interface EntityQuery extends DataQuery {
   queryText?: string;
   constant?: number;
   selectType: SelectableValue;
-  filter: AnalyserNode;
+  filter: API.Filter;
   clauses: any;
 }
 
@@ -27,7 +36,9 @@ export interface Comparator {
 }
 
 export interface SearchType {
-  i: string, l: string, comparators: Comparator[]
+  i: string,
+  l: string,
+  comparators: Comparator[]
 }
 
 export interface SearchOption {
@@ -35,8 +46,8 @@ export interface SearchOption {
   name: string,
   orderBy: boolean,
   label: string,
-  type: SearchType
-  values: string[]
+  type: SearchType,
+  values: string[],
   value?: { values: string[], type: SearchType, id: string, orderBy: boolean, name: string, label: string };
 }
 
@@ -125,7 +136,21 @@ export interface EntityClauseProps {
 }
 
 export interface EntityClauseLabelProps {
-  type: OnmsEntityType, nestingType: OnmsEntityNestType, index: number, setClauseType: Function
+  type: OnmsEntityType,
+  nestingType: OnmsEntityNestType,
+  index: number,
+  setClauseType: Function
+}
+
+export interface OnmsColumn extends Column {
+  resource?: string,
+  featured?: boolean,
+  visible?: boolean
+}
+
+export interface OnmsTableData extends TableData {
+  // override
+  columns: OnmsColumn[]
 }
 
 export type EntityQueryEditorProps = QueryEditorProps<EntityDataSource, EntityQuery, EntityDataSourceOptions>;

--- a/src/datasources/entity-ds-react/useEntityProperties.ts
+++ b/src/datasources/entity-ds-react/useEntityProperties.ts
@@ -12,6 +12,7 @@ export const useEntityProperties = (entityName: string, client: ClientDelegate) 
 
     const loadProperties = async () => {
         let newProperties: API.SearchProperty[] = []
+
         switch (entityName) {
             case EntityTypes.Alarms:
                 newProperties = await client.getAlarmProperties();
@@ -33,6 +34,7 @@ export const useEntityProperties = (entityName: string, client: ClientDelegate) 
                 break;
         }
         let filteredProps = EntityHelper.filterProperties(entityName, newProperties);
+
         setProperties(() => filteredProps)
     }
 

--- a/src/lib/client_delegate.ts
+++ b/src/lib/client_delegate.ts
@@ -163,13 +163,13 @@ export class ClientDelegate {
         .catch(this.decorateError);
     }
 
-    getNodeProperties(): Promise<any[]> {
+    getNodeProperties(): Promise<API.SearchProperty[]> {
         return this.getNodeDao()
             .then((nodeDao) => nodeDao.searchProperties())
             .catch(this.decorateError);
     }
 
-    findNodeProperty(propertyId) {
+    findNodeProperty(propertyId): API.SearchProperty {
         return this.getNodeProperties()
             .then((properties) => {
                 return _.find(properties, (property) => property.id === propertyId);
@@ -211,13 +211,13 @@ export class ClientDelegate {
             .catch(this.decorateError);
     }
 
-    getIpInterfaceProperties(): Promise<any[]> {
+    getIpInterfaceProperties(): Promise<API.SearchProperty[]> {
         return this.getIpInterfaceDao()
             .then((dao) => dao.searchProperties())
             .catch(this.decorateError);
     }
 
-    findIpInterfaceProperty(propertyId) {
+    findIpInterfaceProperty(propertyId): API.SearchProperty {
         return this.getIpInterfaceProperties()
             .then((properties) => {
                 return _.find(properties, (property) => property.id === propertyId);
@@ -259,13 +259,13 @@ export class ClientDelegate {
             .catch(this.decorateError);
     }
 
-    getSnmpInterfaceProperties(): Promise<any[]> {
+    getSnmpInterfaceProperties(): Promise<API.SearchProperty[]> {
         return this.getSnmpInterfaceDao()
             .then((dao) => dao.searchProperties())
             .catch(this.decorateError);
     }
 
-    findSnmpInterfaceProperty(propertyId) {
+    findSnmpInterfaceProperty(propertyId): API.SearchProperty {
         return this.getSnmpInterfaceProperties()
             .then((properties) => {
                 return _.find(properties, (property) => property.id === propertyId);

--- a/src/lib/function_formatter.ts
+++ b/src/lib/function_formatter.ts
@@ -30,6 +30,7 @@ export class FunctionFormatter {
      * Preprocess the parenthesized output so that format object arguments are parameterized
      */
     static parenthesizeWithArguments(label) {
+        try {
         const parenthesized = FunctionFormatter.parenthesize(label);
         return parenthesized.map(entry => {
             if (entry && entry.arguments) {
@@ -41,6 +42,9 @@ export class FunctionFormatter {
             }
             return entry;
         });
+        } catch (e) {
+            return []
+        }
     }
 
     /**


### PR DESCRIPTION
HELM-354: Entity DS React updates, get metricFindQuery and template variables mostly working

Will need more work on this, and looking to get feedback, but this PR does the following:

- Get `metricFindQuery` at least mostly working, particularly for Node queries
- Template variable substitution for Node queries
- Handle some attribute mapping
- Added `OnmsColumn` and `OnmsTableData` to make return values more strongly typed
- Add some more typing for return values, etc.


# External References

* JIRA (Issue Tracker): http://issues.opennms.org/browse/HELM-354
* Continuous Integration: [CircleCI](https://circleci.com/gh/OpenNMS/opennms-helm)
