### PR TITLE
HELM-354: Entity DS React fixes as per PR review suggestions

### DIFF
--- a/src/datasources/entity-ds-react/queries/attributeMappings.ts
+++ b/src/datasources/entity-ds-react/queries/attributeMappings.ts
@@ -11,22 +11,30 @@ export const getAttributeMapping = (entityType: string, attribute: string): stri
 }
 
 const getAttributeMap = (entityType: string) => {
+    let mapping: any = {}
+
     switch (entityType) {
         case EntityTypes.Alarms:
-            return alarmAttributeMapping
+            mapping = alarmAttributeMapping
+            break
         case EntityTypes.Nodes:
-            return nodeAttributeMapping
+            mapping = nodeAttributeMapping
+            break
         case EntityTypes.IPInterfaces:
-            return ipInterfaceAttributeMapping
+            mapping = ipInterfaceAttributeMapping
+            break
         case EntityTypes.SNMPInterfaces:
-            return snmpInterfaceAttributeMapping
+            mapping = snmpInterfaceAttributeMapping
+            break
         case EntityTypes.MonitoredServices:
-            return monitoredServiceAttributeMapping
+            mapping = monitoredServiceAttributeMapping
+            break
         case EntityTypes.Outages:
-            return outageAttributeMapping
-        default:
-            return {}
+            mapping = outageAttributeMapping
+            break
     }
+
+    return mapping
 }
 
 const nodeAttributeMapping = {

--- a/src/lib/client_delegate.ts
+++ b/src/lib/client_delegate.ts
@@ -307,7 +307,7 @@ export class ClientDelegate {
             .catch(this.decorateError);
     }
 
-    getMonitoredServiceProperties(): Promise<any[]> {
+    getMonitoredServiceProperties(): Promise<API.SearchProperty[]> {
         return this.getMonitoredServiceDao()
             .then((dao) => dao.searchProperties())
             .catch(this.decorateError);
@@ -355,7 +355,7 @@ export class ClientDelegate {
             .catch(this.decorateError);
     }
 
-    getOutageProperties(): Promise<any[]> {
+    getOutageProperties(): Promise<API.SearchProperty[]> {
         return this.getOutageDao()
             .then((dao) => dao.searchProperties())
             .catch(this.decorateError);


### PR DESCRIPTION
Various fixes to React Entity Datasource as per previous PR review suggestions.

- return once at end of `switch/case` statements
- move some helper functions from `EntityDatasource` into `EntityHelpers`
- remove explicit `Promise` statements from `async` functions
- fix `templateSrv.variables` -> `templateSrv.getVariables()` (`.variables` was deprecated), but only in new datasource
- a couple other small fixes

# External References

* JIRA (Issue Tracker): http://issues.opennms.org/browse/HELM-354
* Continuous Integration: [CircleCI](https://circleci.com/gh/OpenNMS/opennms-helm)
