### PR TITLE
HELM-360: Wire up React Filter Panel with Entity DataSource

### DIFF
--- a/src/datasources/entity-ds-react/EntityHelper.tsx
+++ b/src/datasources/entity-ds-react/EntityHelper.tsx
@@ -130,18 +130,18 @@ export const filterProperties = (entityName: string, fullProperties: API.SearchO
     return properties
 }
 
+const entityQueries = [
+    ['alarms', EntityTypes.Alarms],
+    ['ipInterface', EntityTypes.IPInterfaces],
+    ['monitoredService', EntityTypes.MonitoredServices],
+    ['nodes', EntityTypes.Nodes],
+    ['nodeFilter', EntityTypes.Nodes],
+    ['outage', EntityTypes.Outages],
+    ['snmpInterface', EntityTypes.SNMPInterfaces]
+]
+
 export const getEntityTypeFromFuncName = (funcName: string) => {
     // key is start of function name, this will also match e.g. 'outage()' and 'outages()'
-    const entityQueries = [
-        ['alarms', EntityTypes.Alarms],
-        ['ipInterface', EntityTypes.IPInterfaces],
-        ['monitoredService', EntityTypes.MonitoredServices],
-        ['nodes', EntityTypes.Nodes],
-        ['nodeFilter', EntityTypes.Nodes],
-        ['outage', EntityTypes.Outages],
-        ['snmpInterface', EntityTypes.SNMPInterfaces]
-    ]
-
     if (funcName) {
         const item = entityQueries.find(d => funcName.startsWith(d[0]))
         if (item) {
@@ -150,6 +150,22 @@ export const getEntityTypeFromFuncName = (funcName: string) => {
     }
 
     return null
+}
+
+/**
+ * Given an EntityType, return the entity datasource function name for it. 
+ */
+export const getFuncNameFromEntityType = (entityType: string) => {
+
+    if (entityType) {
+        const item = entityQueries.find(d => entityType === d[1])
+
+        if (item) {
+            return item[0]
+        }
+    }
+
+    return ''
 }
 
 /**

--- a/src/hooks/useEntities.tsx
+++ b/src/hooks/useEntities.tsx
@@ -1,3 +1,5 @@
+import { getFuncNameFromEntityType } from '../datasources/entity-ds-react/EntityHelper'
+
 export const useEntities = () => {
     const entities = [
         { label: 'Alarms', value: '0' },
@@ -7,5 +9,9 @@ export const useEntities = () => {
         { label: 'Monitored Services', value: '4'},
         { label: 'Outages', value: '5' },
     ]
-    return entities
+
+    return {
+        entities,
+        getFuncNameFromEntityType
+    }
 }

--- a/src/lib/localStorageService.ts
+++ b/src/lib/localStorageService.ts
@@ -1,3 +1,5 @@
+import { FilterEditorData } from '../panels/filter-panel-react/FilterPanelTypes'
+
 const getCircularReplacer = () => {
     const seen = new WeakSet();
     return (key, value) => {
@@ -11,6 +13,19 @@ const getCircularReplacer = () => {
     };
 };
 
-export const saveFilterPanel = (info: any) => {
-    localStorage.setItem('opennms-helm-filter-panel', JSON.stringify(info, getCircularReplacer()))
+const FILTER_PANEL_STORAGE_KEY = 'opennms-helm-filter-panel'
+
+export const saveFilterEditorData = (data: FilterEditorData) => {
+    localStorage.setItem(FILTER_PANEL_STORAGE_KEY, JSON.stringify(data, getCircularReplacer()))
+}
+
+export const loadFilterEditorData = (): FilterEditorData | null => {
+    const json = localStorage.getItem(FILTER_PANEL_STORAGE_KEY)
+
+    if (json) {
+        const filterPanel = JSON.parse(json)
+        return filterPanel as FilterEditorData
+    }
+
+    return null
 }

--- a/src/panels/filter-panel-react/FilterPanelActiveFilters.tsx
+++ b/src/panels/filter-panel-react/FilterPanelActiveFilters.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from 'react'
+import React from 'react'
 import { Button, Label, SegmentInput, Select } from '@grafana/ui'
 import { FieldDisplay } from 'components/FieldDisplay';
 import { ActiveFilter } from './FilterPanelTypes';
@@ -6,64 +6,44 @@ import { SelectableValue } from '@grafana/data';
 
 interface FilterPanelActiveFiltersProps {
     activeFilters: ActiveFilter[],
-    setActiveFilters: Function,
     onChange: Function
 }
-export const FilterPanelActiveFilters: React.FC<FilterPanelActiveFiltersProps> = ({ activeFilters, setActiveFilters, onChange }) => {
-    const [filterSelectionTypes, setFilterSelectionTypes] = useState<Array<SelectableValue<string>>>([]);
-    const [altColumnLabels, setAltColumnLabels] = useState<string[]>([]);
-    useEffect(() => {
-        onChange({ altColumnLabels, filterSelectionTypes })
-        // eslint-disable-next-line react-hooks/exhaustive-deps
-    }, [altColumnLabels, filterSelectionTypes])
 
+export const FilterPanelActiveFilters: React.FC<FilterPanelActiveFiltersProps> = ({ activeFilters, onChange }) => {
     const updateFilterSelectionType = (value: SelectableValue<string>, index: number) => {
-        setFilterSelectionTypes((oldTypes) => {
-            const newTypes = [...oldTypes]
-            if (value) {
-                newTypes[index] = value;
-            }
-            return newTypes;
-        })
+        const newFilters = [...activeFilters]
+        newFilters[index].selectionType = value
+        onChange(newFilters)
     }
 
     const updateAltColumnLabels = (value: string | number, index: number) => {
-        setAltColumnLabels((oldLabels) => {
-            const newLabels = [...oldLabels]
-            if (typeof value === 'string') {
-                newLabels[index] = value;
-            }
-            return newLabels;
-        })
-        
+        if (typeof value === 'string') {
+            const newFilters = [...activeFilters]
+            newFilters[index].altColumnLabel = value
+            onChange(newFilters)
+        }
     }
 
     const removeFieldRow = (index: number) => {
-        setActiveFilters((oldFilters) => {
-            const newFilters = [...oldFilters]
-            newFilters.splice(index, 1)
-            return newFilters;
-        })
+        const newFilters = [...activeFilters]
+        newFilters.splice(index, 1)
+        onChange(newFilters)
     }
 
     const moveFieldDown = (index: number) => {
-        setActiveFilters((oldFilters) => {
-            const newFilters = [...oldFilters]
-            var stored = newFilters[index];
-            newFilters.splice(index, 1);
-            newFilters.splice(index + 1, 0, stored);
-            return newFilters;
-        })
+        const newFilters = [...activeFilters]
+        var stored = newFilters[index];
+        newFilters.splice(index, 1);
+        newFilters.splice(index + 1, 0, stored);
+        onChange(newFilters)
     }
 
     const moveFieldUp = (index: number) => {
-        setActiveFilters((oldFilters) => {
-            const newFilters = [...oldFilters]
-            var stored = newFilters[index];
-            newFilters.splice(index, 1);
-            newFilters.splice(index - 1, 0, stored);
-            return newFilters;
-        })
+        const newFilters = [...activeFilters]
+        var stored = newFilters[index];
+        newFilters.splice(index, 1);
+        newFilters.splice(index - 1, 0, stored);
+        onChange(newFilters)
     }
 
     return (
@@ -90,7 +70,7 @@ export const FilterPanelActiveFilters: React.FC<FilterPanelActiveFiltersProps> =
                                     <FieldDisplay>{filter?.entity?.label}</FieldDisplay>
                                     <SegmentInput
                                         placeholder={filter?.attribute?.label}
-                                        value={altColumnLabels[index]}
+                                        value={filter.altColumnLabel}
                                         onChange={(e) => updateAltColumnLabels(e, index)}
                                     />
                                     <div
@@ -106,7 +86,7 @@ export const FilterPanelActiveFilters: React.FC<FilterPanelActiveFiltersProps> =
                                                 { label: 'Text', value: 'text' }
                                             ]}
                                             onChange={(e) => updateFilterSelectionType(e, index)}
-                                            value={filterSelectionTypes[index] || { label: 'Single', value: 'single' }}
+                                            value={filter.selectionType || { label: 'Single', value: 'single' }}
                                         />
                                         <Button
                                             disabled={index === 0}

--- a/src/panels/filter-panel-react/FilterPanelControl.tsx
+++ b/src/panels/filter-panel-react/FilterPanelControl.tsx
@@ -1,45 +1,217 @@
-import { PanelProps } from '@grafana/data'
-import { HorizontalGroup, Input, Select } from '@grafana/ui'
+import React, { useEffect, useState } from 'react'
+import { MetricFindValue, PanelProps, SelectableValue } from '@grafana/data'
+import { getDataSourceSrv } from "@grafana/runtime"
+import { HorizontalGroup, Input, Select, VerticalGroup } from '@grafana/ui'
 import { FieldDisplay } from 'components/FieldDisplay'
-import { saveFilterPanel } from 'lib/localStorageService'
-import React, { useEffect } from 'react'
-import { FilterControlProps } from './FilterPanelTypes'
+import { loadFilterEditorData, saveFilterEditorData } from 'lib/localStorageService'
+import { useEntities } from '../../hooks/useEntities'
+import { getFilterId } from './FilterPanelHelper'
+import { ActiveFilter, FilterControlProps, FilterEditorData, FilterSelectableValues } from './FilterPanelTypes'
 
 export const FilterPanelControl: React.FC<PanelProps<FilterControlProps>> = (props) => {
+    const { getFuncNameFromEntityType } = useEntities()
 
-    const getSelectOptions = (filter) => {
-        // TODO: Replace these fake values with the real ones when we can get them from metricfindquery
-        return props?.options?.filterEditor?.properties?.[filter.attribute.value?.id].values ||
-            [{ value: "1", label: '1' }, { value: "2", label: '2' }]
-    }
+    // array of metric values for each filter id
+    const [metricValues, setMetricValues] = useState<Array<[string, MetricFindValue[]]>>([])
 
-    const selectChanged = () => {
-        //TODO: When these values are real, store this selection.
-    }
-
+    // array of selectable values for each filter id
+    const [selectableValues, setSelectableValues] = useState<FilterSelectableValues[]>([])
 
     useEffect(() => {
-        if (props.options.filterEditor) {
-            saveFilterPanel(props.options.filterEditor)
-        }
-    }, [props.options.filterEditor])
-    return (
-        <HorizontalGroup align='flex-start'>
-            {props.options?.filterEditor?.activeFilters.map((filter, index) => {
+        const filterEditorData = loadFilterEditorData()
 
-                return (
-                    <HorizontalGroup key={index}>
-                        <FieldDisplay>{props.options.filterEditor.altColumnLabels[index] || filter.attribute.label}</FieldDisplay>
-                        {props.options.filterEditor.filterSelectionTypes[index]?.label === 'Text' ?
-                            <Input />
-                            : <Select
-                                isMulti={props.options.filterEditor.filterSelectionTypes[index]?.label === 'Multi'}
-                                options={getSelectOptions(filter)}
-                                onChange={selectChanged}></Select>
-                        }
-                    </HorizontalGroup>
-                )
-            })}
-        </HorizontalGroup>
+        if (filterEditorData && filterEditorData.selectableValues) {
+            setSelectableValues(filterEditorData.selectableValues)
+        }
+        // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, [])
+
+    useEffect(() => {
+        const fetchMetricValues = async () => {
+            const newMetricValues: Array<[string, MetricFindValue[]]> = []
+            let shouldUpdate = false
+
+            // loop through filters, create metricValues entry for each
+            for (const filter of props.options.filterEditor.activeFilters || []) {
+                const filterId = getFilterId(filter)
+                const [key, values] = metricValues.find(([k,v]) => k === filterId) || []
+
+                if (key) {
+                    // key already existed, assume values were already fetched
+                    newMetricValues.push([key, values || []])
+                } else {
+                    // values were not previously retrieved
+                    const newValues = await getValuesFromDatasource(filter)
+                    newMetricValues.push([filterId, newValues])
+                    shouldUpdate = true
+                }
+            }
+
+            if (shouldUpdate) {
+                setMetricValues(newMetricValues)
+            }
+        }
+
+        fetchMetricValues()
+
+        // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, [props])
+
+    /**
+     * Loop through active filters. For all filters that don't have metric values,
+     * retrieve them from Entity Datasource and store them.
+     */
+    const getValuesFromDatasource = async (filter: ActiveFilter) => {
+        const grafanaDatasource = props.options.filterEditor?.datasource?.value
+
+        if (grafanaDatasource && grafanaDatasource?.id) {
+            const datasourceSrv = getDataSourceSrv()
+            const qualifiedDatasource = await datasourceSrv.get(grafanaDatasource)
+
+            if (qualifiedDatasource && qualifiedDatasource.metricFindQuery) {
+                const entityFunc = getFuncNameFromEntityType(filter.entity.label ?? '')
+                const entity = (filter.entity.label || '').toLowerCase()
+                const attr = filter.attribute.id
+
+                if (entity && attr) {
+                    const opts = { entityType: entity }
+                    const query = `${entityFunc}(${attr})`
+
+                    const metricFindValues = await qualifiedDatasource.metricFindQuery(query, opts)
+
+                    // got values from the datasource, store them and set update flag
+                    if (metricFindValues.length > 0) {
+                        return metricFindValues
+                    }
+                }
+            }
+        }
+
+        return []
+    }
+
+    const generateFilterSelectOptions = (filter: ActiveFilter) => {
+        const filterId = getFilterId(filter)
+        const [key, currentValues] = metricValues.find(([k,v]) => k === filterId) || []
+
+        if (key && currentValues) {
+            const values = currentValues.map(v => ({
+                label: v.text,
+                value: v.value || ''
+            } as SelectableValue<string | number>))
+
+            return values
+        }
+
+        return []
+    }
+
+    const filterDisplayLabel = (filter: ActiveFilter, index: number) => {
+        const altLabel = filter.altColumnLabel
+
+        if (altLabel) {
+            return altLabel
+        }
+
+        return `${filter.entity.label || ''}: ${filter.attribute.label || ''}`
+    }
+
+    const getInputSelectableValue = (filter: ActiveFilter) => {
+        const filterId = getFilterId(filter)
+        const selVals = selectableValues.find(v => v.filterId === filterId)
+
+        if (selVals && selVals.values?.length > 0) {
+            return selVals.values[0].value || ''
+        }
+
+        return ''
+    }
+
+    const getSelectSelectableValues = (filter: ActiveFilter) => {
+        const filterId = getFilterId(filter)
+        const selVals = selectableValues.find(v => v.filterId === filterId)
+
+        return (selVals && selVals.values) || []
+    }
+
+    const inputChanged = (e, filter: ActiveFilter) => {
+        const filterId = getFilterId(filter)
+        const newValues = selectableValues.filter(v => v.filterId !== filterId)
+
+        const newValue = {
+            label: '',
+            value: (e.target.value || '') as string
+        }
+
+        const newEntry = {
+            filterId,
+            values: [newValue]
+        } as FilterSelectableValues
+
+        newValues.push(newEntry)
+        setSelectableValues(newValues)
+        saveFilterPanel(newValues)
+    }
+
+    const selectChanged = (value: (SelectableValue | SelectableValue[]), filter: ActiveFilter) => {
+        const filterId = getFilterId(filter)
+        const newValue = Array.isArray(value) ? value : [value]
+        const newValues = selectableValues.filter(v => v.filterId !== filterId)
+
+        const newEntry = {
+            filterId,
+            values: newValue
+        } as FilterSelectableValues
+
+        newValues.push(newEntry)
+        setSelectableValues(newValues)
+        saveFilterPanel(newValues)
+    }
+
+    /**
+     * Save filter panel data to localStorage, for use by Entity Datasource when filtering queries.
+     */
+    const saveFilterPanel = (filterSelectableValues: FilterSelectableValues[]) => {
+        if (props.options.filterEditor) {
+            // TODO: May want to remove some data from datasource before saving
+            const filterData: FilterEditorData = {
+                ...props.options.filterEditor,
+                selectableValues: filterSelectableValues
+            }
+
+            saveFilterEditorData(filterData)
+        }
+    }
+
+    useEffect(() => {
+        saveFilterPanel(selectableValues)
+        // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, [props.options.filterEditor])
+
+    return (
+        <div style={{ height: '100%', overflowY: 'auto' }}>
+            <VerticalGroup align='flex-start'>
+                {props.options?.filterEditor?.activeFilters?.map &&
+                 props.options?.filterEditor?.activeFilters.map((filter, index) => { 
+                    return (
+                        <HorizontalGroup key={getFilterId(filter)}>
+                            <FieldDisplay>{filterDisplayLabel(filter, index)}</FieldDisplay>
+                            {filter.selectionType?.label === 'Text' ?
+                                <Input
+                                   value={getInputSelectableValue(filter)} 
+                                   onChange={(e) => inputChanged(e, filter)}
+                                />
+                                : <Select
+                                    isMulti={filter.selectionType?.label === 'Multi'}
+                                    options={generateFilterSelectOptions(filter)}
+                                    value={getSelectSelectableValues(filter)}
+                                    menuShouldPortal={true}
+                                    onChange={(value) => selectChanged(value, filter)}></Select>
+                            }
+                        </HorizontalGroup>
+                    )
+                })}
+            </VerticalGroup>
+        </div>
     )
 }

--- a/src/panels/filter-panel-react/FilterPanelDataSource.tsx
+++ b/src/panels/filter-panel-react/FilterPanelDataSource.tsx
@@ -1,25 +1,26 @@
 import { SelectableValue } from '@grafana/data';
 import { InlineField, Select } from '@grafana/ui'
 import { GrafanaDatasource, useDatasources } from 'hooks/useDataSources';
-import React, { useState, useEffect } from 'react'
+import React from 'react'
 
-export const FilterPanelDataSource: React.FC<{ onChange: Function }> = ({ onChange }) => {
+interface FilterPanelDataSourceProps {
+    datasource?: SelectableValue<GrafanaDatasource>,
+    onChange: Function
+}
 
+export const FilterPanelDataSource: React.FC<FilterPanelDataSourceProps> = ({ datasource, onChange }) => {
     const allowedDatasources = ['opennms-helm-entity-datasource-react']
     const { datasources } = useDatasources();
     const entityDatasources = datasources?.filter((d) => allowedDatasources.includes(d.type))
-    const [datasource, setDatasource] = useState<SelectableValue<GrafanaDatasource>>()
     const selectOptions: Array<SelectableValue<GrafanaDatasource>> = entityDatasources?.map((d) => ({ label: d.name, value: d }))
-    useEffect(() => {
-        if (datasource) {
-            onChange(datasource);
-        }
-        // eslint-disable-next-line react-hooks/exhaustive-deps
-    }, [datasource])
+
     return (
         <InlineField label='Data source entity'>
             <div style={{ display: 'flex', gap: '10px' }}>
-                <Select options={selectOptions} onChange={(e) => setDatasource(e)} value={datasource} />
+                <Select
+                    options={selectOptions}
+                    onChange={(e) => onChange(e)}
+                    value={datasource} />
             </div>
         </InlineField>
     )

--- a/src/panels/filter-panel-react/FilterPanelFilterSelector.tsx
+++ b/src/panels/filter-panel-react/FilterPanelFilterSelector.tsx
@@ -1,48 +1,101 @@
-import React, { useState } from 'react';
-import { Button, HorizontalGroup, Label, Select } from '@grafana/ui'
-import { GrafanaDatasource } from 'hooks/useDataSources';
-import { ClientDelegate } from 'lib/client_delegate';
-import { useEntityProperties } from 'hooks/useEntityProperties';
-import { ActiveFilter } from './FilterPanelTypes';
-import { SelectableValue } from '@grafana/data';
-import { useEntities } from 'hooks/useEntities';
+import React, { useState } from 'react'
+import { SelectableValue } from '@grafana/data'
+import {
+    Button,
+    HorizontalGroup,
+    InlineField,
+    InlineFieldRow,
+    Label,
+    Select,
+    Switch
+} from '@grafana/ui'
+import { GrafanaDatasource } from 'hooks/useDataSources'
+import { useEntities } from 'hooks/useEntities'
+import { useEntityProperties } from 'hooks/useEntityProperties'
+import { ClientDelegate } from 'lib/client_delegate'
+import { getFilterId, getFilterIdFromParts } from './FilterPanelHelper'
+import { ActiveFilter } from './FilterPanelTypes'
 
 interface FilterPanelFilterSelectorProps {
     datasource?: GrafanaDatasource,
-    onChange: Function,
+    activeFilters: ActiveFilter[],
     client?: ClientDelegate,
-    activeFilters: ActiveFilter[]
-    setActiveFilters: Function
+    onChange: Function
 }
 
-export const FilterPanelFilterSelector: React.FC<FilterPanelFilterSelectorProps> = ({ datasource, onChange, client,activeFilters,setActiveFilters }) => {
-    const entityOptions = useEntities();
+export const FilterPanelFilterSelector: React.FC<FilterPanelFilterSelectorProps> =
+    ({ datasource, activeFilters, client, onChange }) => {
+
+    const { entities: entityOptions } = useEntities();
     const [entity, setEntity] = useState<SelectableValue<string>>()
     const [attribute, setAttribute] = useState<SelectableValue<{ id: string }>>()
-    const { propertiesAsArray } = useEntityProperties(entity?.label || '', false, client as any)
-    const disabled = !entity || !attribute || !datasource || attribute.label === 'Select Attribute';
+    const [featuredAttributes, setFeaturedAttributes] = useState<boolean>(true)
+    const { propertiesAsArray } = useEntityProperties(entity?.label || '', featuredAttributes, client as any)
+
+    const isDisabled = () => {
+        if (!entity || !attribute || !datasource || attribute.label === 'Select Attribute') {
+            return true
+        }
+
+        // prevent adding duplicate filters
+        const filterId = getFilterIdFromParts(entity, attribute)
+        return activeFilters.some(f => getFilterId(f) === filterId)
+    }
+
+    /**
+     * Values in propertiesAsArray contains additional properties such as 'valueProvider'
+     * which are very large and cause circular references (causing issues with JSON.stringify)
+     * and are not needed. We just return the necessary properties here
+     */
+    const getAttributeOptions = () => {
+        return propertiesAsArray.map(p => ({
+            id: p.id,
+            label: p.label,
+            name: p.name,
+            orderBy: p.orderBy,
+            value: p.value,
+            type: p.type
+        }))
+    }
+
     const addFilterRow = () => {
-        setActiveFilters((oldFilters) => {
-            let newFilters: any = []
-            if (oldFilters) {
-                newFilters = [...oldFilters]
-                newFilters.push({ entity, attribute })
-            }
-            return newFilters;
-        })
+        let newFilters: any = []
+        if (activeFilters) {
+            newFilters = [...activeFilters]
+            newFilters.push({ entity, attribute })
+        }
+
+        onChange(newFilters)
         setAttribute({ label: 'Select Attribute' })
     }
-   
+
     return (
         <>
-            <Label style={{ marginTop: 12 }}>
+            <style>
+                {`
+                    .spacer {
+                        margin-bottom: 6px;
+                    }
+                `}
+            </style>
+             <Label style={{ marginTop: 12 }}>
                 Filters
             </Label>
             <HorizontalGroup>
                 <Select placeholder='Entity' options={entityOptions} onChange={(e) => setEntity(e)} value={entity} />
-                <Select placeholder='Attribute' options={propertiesAsArray} onChange={(e) => setAttribute(e)} value={attribute} />
-                <Button disabled={disabled} onClick={addFilterRow}>Add Filter Row</Button>
+                <Select placeholder='Attribute' options={getAttributeOptions()} onChange={(e) => setAttribute(e)} value={attribute} />
+                <Button disabled={isDisabled()} onClick={addFilterRow}>Add Filter Row</Button>
             </HorizontalGroup>
+            <div className='spacer' />
+            <InlineFieldRow>
+                <InlineField label='Featured attributes'>
+                    <div style={{ display: 'flex', alignItems: 'center', height: '32px' }}>
+                        <Switch
+                            value={featuredAttributes}
+                            onChange={() => setFeaturedAttributes(!featuredAttributes)} />
+                    </div>
+                </InlineField>
+            </InlineFieldRow>
         </>
     )
 }

--- a/src/panels/filter-panel-react/FilterPanelHelper.ts
+++ b/src/panels/filter-panel-react/FilterPanelHelper.ts
@@ -1,0 +1,13 @@
+import { SelectableValue } from '@grafana/data'
+import { ActiveFilter } from './FilterPanelTypes'
+
+export const getFilterIdFromParts = (entity: SelectableValue<string | number>, attribute: SelectableValue) => {
+    const entityName = (entity.label || entity.value || '').toString()
+    const attrName = attribute.id || attribute.label || ''
+
+    return `${entityName}_${attrName}`
+}
+
+export const getFilterId = (filter: ActiveFilter) => {
+    return getFilterIdFromParts(filter.entity, filter.attribute)
+}

--- a/src/panels/filter-panel-react/FilterPanelOptions.tsx
+++ b/src/panels/filter-panel-react/FilterPanelOptions.tsx
@@ -1,29 +1,27 @@
+import React, { useState, useEffect } from 'react'
 import { PanelOptionsEditorProps, SelectableValue } from '@grafana/data'
 import { GrafanaDatasource } from 'hooks/useDataSources';
 import { useOpenNMSClient } from '../../hooks/useOpenNMSClient'
-import React, { useState, useEffect } from 'react'
 import { ActiveFilter } from './FilterPanelTypes';
 import { FilterPanelDataSource } from './FilterPanelDataSource'
 import { FilterPanelFilterSelector } from './FilterPanelFilterSelector';
 import { FilterPanelActiveFilters } from './FilterPanelActiveFilters';
+import { loadFilterEditorData } from 'lib/localStorageService'
 
 interface FilterPanelOptionOptions {
     datasource: SelectableValue<GrafanaDatasource>
     activeFilters: ActiveFilter[]
 }
-export const FilterPanelOptions: React.FC<PanelOptionsEditorProps<{}>> = (props) => {
-    const [activeFilters, setActiveFilters] = useState<ActiveFilter[]>([])
-    const [internalOptions, setInternalOptions] = useState<FilterPanelOptionOptions>({ datasource: {}, activeFilters: [] })
+
+export const FilterPanelOptions: React.FC<PanelOptionsEditorProps<FilterPanelOptionOptions>> = (props) => {
+    const [internalOptions, setInternalOptions] = useState<FilterPanelOptionOptions>(
+        {
+            datasource: props.context.options?.datasource || {},
+            activeFilters: props.context.options?.activeFilters || []
+        })
     const { client } = useOpenNMSClient(internalOptions?.datasource?.value)
  
-    useEffect(() => {
-        if (activeFilters){
-            onOptionChange(activeFilters,'activeFilters')
-        }
-    },[activeFilters])
-
     const onOptionChange = (v, k) => {
-
         setInternalOptions((oldOptions) => {
             const newOptions = { ...oldOptions }
             newOptions[k] = v
@@ -32,54 +30,40 @@ export const FilterPanelOptions: React.FC<PanelOptionsEditorProps<{}>> = (props)
     }
 
     useEffect(() => {
+        const data = loadFilterEditorData()
+
+        if (data && data.datasource && data.activeFilters) {
+            setInternalOptions({
+                datasource: data.datasource,
+                activeFilters: data.activeFilters
+            })
+        }
+        // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, [])
+
+    useEffect(() => {
         props.onChange({
             ...internalOptions
         })
         // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [internalOptions])
 
-    /*
-        TODO: When the entity datasource metric find query is working better, retry this stuff below.
-    const getPropertiesFromDatasource = async () => {
-         
-          const datasourceSrv = getDataSourceSrv()
-          const qualifiedDatasource = await datasourceSrv.get(datasource?.value)
-          const opts = {
-              queryType: 'attributes',
-          };
-          if (entity) {
-              opts['entityType'] = entity.id;
-          }
-          if (qualifiedDatasource && qualifiedDatasource.metricFindQuery) {
-              const activeProperties = await qualifiedDatasource.metricFindQuery(entity, opts)
-              // TODO: When this return active values, store them and show them in the Filter Control
-          } 
-          
-    }
-    TODO: See above why this is temporarily disabled.
-    useEffect(() => {
-        getPropertiesFromDatasource();
-        // eslint-disable-next-line react-hooks/exhaustive-deps
-    }, [datasource])
-    */
-
-
     return (
         <>
-            <FilterPanelDataSource onChange={(d) => onOptionChange(d, 'datasource')} />
+            <FilterPanelDataSource
+                onChange={(d) => onOptionChange(d, 'datasource')}
+                datasource={internalOptions.datasource}
+            />
             <FilterPanelFilterSelector
-                activeFilters={activeFilters}
-                setActiveFilters={setActiveFilters}
+                activeFilters={internalOptions.activeFilters}
                 client={client}
-                datasource={internalOptions?.datasource.value}
+                datasource={internalOptions.datasource.value}
                 onChange={(d) => onOptionChange(d, 'activeFilters')}
             />
             <FilterPanelActiveFilters
-                activeFilters={internalOptions?.activeFilters || []}
-                setActiveFilters={setActiveFilters}
-                onChange={(d) => setInternalOptions((oldOptions) => ({ ...oldOptions, ...d }))}
+                activeFilters={internalOptions.activeFilters}
+                onChange={(d) => onOptionChange(d, 'activeFilters')}
             />
-
         </>
     )
 }

--- a/src/panels/filter-panel-react/FilterPanelTypes.ts
+++ b/src/panels/filter-panel-react/FilterPanelTypes.ts
@@ -1,17 +1,35 @@
 import { SelectableValue } from "@grafana/data"
 import { GrafanaDatasource } from "hooks/useDataSources"
-import { SearchProperty } from "opennms/src/API"
 
+/**
+ * entity: Entity name for filter (e.g. "nodes", "alarms")
+ * attribute: Entity attribute to filter on (e.g. "id", "label", "Alarm Type")
+ * values: Set of values for that entity and attribute from entityDatasource.metricFindQuery()
+ * selectionType: whether this filter is single/multi/text
+ * altColumnLabel: User customized label for this filter, to display on FilterPanelControl component
+ */
 export interface ActiveFilter {
-    attribute: SelectableValue<{ id: string | number }>,
-    entity: SelectableValue<string | number>,
+    entity: SelectableValue<string | number>
+    attribute: SelectableValue<{ id: string | number }>
+    selectionType: SelectableValue<string>
+    altColumnLabel: string
 }
+
 export interface FilterControlProps {
     filterEditor: {
         datasource: SelectableValue<GrafanaDatasource> | undefined,
-        activeFilters: ActiveFilter[],
-        properties: Record<string,SearchProperty>,
-        filterSelectionTypes: Array<SelectableValue<string>>,
-        altColumnLabels: string[],
+        activeFilters: ActiveFilter[]
     }
+}
+
+export interface FilterSelectableValues {
+    filterId: string,
+    values: Array<SelectableValue<string | number>>
+}
+
+// FilterPanel data saved to localStorage for use by Entity Datasource
+export interface FilterEditorData {
+    datasource: SelectableValue<GrafanaDatasource> | undefined,
+    activeFilters: ActiveFilter[]
+    selectableValues: FilterSelectableValues[]
 }


### PR DESCRIPTION
HELM-360: Wire up React Filter Panel with Entity DataSource plus other updates.

## Overview

Connect the React FilterPanel to the React Entity DataSource, both for `metricFindQuery` queries for getting Filter Panel properties, as well as applying the Filter Panel selections to Entity DataSource queries.

While Grafana template variables can be used, the Filter Panel also allows filtering to be done over all panels in a dashboard without having to first specify template queries.

- Filter Panel selections are saved in browser Local Storage for use by the Entity DataSource

- changes made in Filter Panel Options editor are immediately reflected in the Filter Panel and most data is retained in local storage

- note, user needs to click the Dashboard Refresh button before Entity DataSource is re-queried and other panels update

- Filter Panel filters are applied in Entity DataSource per entity query, filters are added after any others. Handles both single and multi filter property selection

- changed Filter Panel filters to be displayed in rows instead of one long column. Filter Panel is scrollable and dropdowns display over any other adjacent panels

- user can select between Featured Attributes being displayed or not in the Filter Panel Options editor

- there were issues syncing filter order between Options and Control panels, and for example syncing metric values with the associated filter, by just using array indices, so needed to use a filterId (entity name + attribute) as a unique identifier. Also, metric data (i.e. sample values for filter items) is only saved in the Filter Panel itself and not in local storage or Options data

## Additional notes or items for future consideration:

- Filter Panel data, including filter definitions and actual filter values selected, is saved in browser local storage. Then, the React Entity DataSource checks for it before any query. Assuming this won't be a performance issue.

- Local storage could be retained even after any Filter Panels have been deleted. Should consider both Filter Panel having a hook to delete data when panel is deleted; and/or Entity DS should check for existence of a Filter Panel on current Dashboard

- May need to remove any sensitive info (credentials, etc.) from Entity DS data saved in local storage. May require then retrieving and possibly caching it

- Local storage may be removed during browser refresh or timeouts, user may lose actual Filter Panel value selections in those cases.

# External References

* JIRA (Issue Tracker): https://opennms.atlassian.net/browse/HELM-360
* Continuous Integration: [CircleCI](https://circleci.com/gh/OpenNMS/opennms-helm)
