### PR TITLE
ALEC-267: Remove reference to apt-key in examples

### DIFF
--- a/docs/modules/installation/pages/debian.adoc
+++ b/docs/modules/installation/pages/debian.adoc
@@ -23,7 +23,7 @@ Import the packages' authentication key with the following command:
 .GPG key import for Debian-based systems
 [source, console]
 ----
-wget -O - https://debian.opennms.org/OPENNMS-GPG-KEY | sudo apt-key add -
+wget -O- https://debian.opennms.org/OPENNMS-GPG-KEY | tee -a /etc/apt/trusted.gpg.d/opennms.asc
 ----
 
 Install the packages:


### PR DESCRIPTION
ALEC-267: Remove reference to apt-key in examples - updated the command as per description in ticket for the same issue in ALEC.

# Pull Request Check Sheet

* [ ] Have you read and followed our [Contribution Guidelines](https://github.com/OpenNMS/opennms/blob/develop/CONTRIBUTING.md)?
* [ ] Have you [made an issue in the OpenNMS issue tracker](https://issues.opennms.org)?<br>If so, you should:
  1. update the title of this PR to be of the format: `${JIRA-ISSUE-NUMBER}: subject of pull request`
  2. update the JIRA link at the bottom of this comment to refer to the real issue number
  3. prefix your commit messages with the issue number, if possible
* [ ] Have you made a comment in that issue which points back to this PR?
* [ ] Have you updated the JIRA link at the bottom of this comment to link to your issue?
* [ ] If this is a new feature, is there documentation?
* [ ] If this is a new feature or substantial change, are there tests that cover it?

# Pull Request Process

One or more reviewers should be assigned to each PR.

If you know that a particular person is subject matter expert in the area your PR affects, feel free to assign one or more reviewers when you create this PR, otherwise reviewers will be assigned for you.

Once the reviewer(s) accept the PR and the branch passes continuous integration in Bamboo, the PR is eligible for merge.

At that time, if you have commit access (are an OpenNMS Group employee or a member of the Order of the Green Polo) you are welcome to merge the PR.
Otherwise, a reviewer can merge it for you.

Thanks for taking time to contribute!

# External References

* JIRA (Issue Tracker): http://issues.opennms.org/browse/ALEC-267
* Continuous Integration: [CircleCI](https://circleci.com/gh/OpenNMS/opennms-helm)
