### PR TITLE
HELM-331: Performance Datasource React conversion work

### DIFF
--- a/src/components/SwitchBox.tsx
+++ b/src/components/SwitchBox.tsx
@@ -1,7 +1,13 @@
 import React from 'react'
-export const SwitchBox: React.FC = ({children}) => {
+
+export interface SwitchBoxProps {
+    className?: string;
+    children: React.ReactNode;
+}
+
+export const SwitchBox: React.FC<SwitchBoxProps> = ({className = undefined, children }) => {
     return (
-        <div style={{display:'flex',alignItems:'center',height:32,width:32}}>
+        <div className={className} style={{ display: 'flex', alignItems: 'center', height: 32, width: 32 }}>
             {children}
         </div>
     )

--- a/src/datasources/perf-ds-react/PerformanceConfigEditor.tsx
+++ b/src/datasources/perf-ds-react/PerformanceConfigEditor.tsx
@@ -1,6 +1,6 @@
+import React from 'react';
 import { DataSourcePluginOptionsEditorProps } from '@grafana/data';
 import { DataSourceHttpSettings } from '@grafana/ui';
-import React from 'react';
 import { PerformanceDataSourceOptions } from './types';
 
 interface Props extends DataSourcePluginOptionsEditorProps<PerformanceDataSourceOptions> { }
@@ -12,5 +12,5 @@ export const PerformanceConfigEditor: React.FC<Props> = ({ onOptionsChange, opti
             dataSourceConfig={options}
             onChange={onOptionsChange}
         />
-    );
-};
+    )
+}

--- a/src/datasources/perf-ds-react/PerformanceExpression.tsx
+++ b/src/datasources/perf-ds-react/PerformanceExpression.tsx
@@ -1,14 +1,16 @@
+import React, { useState, useEffect } from 'react'
 import { SegmentInput } from '@grafana/ui';
 import { SegmentSectionWithIcon } from 'components/SegmentSectionWithIcon';
-import React, { useState, useEffect } from 'react'
 
 export const PerformanceExpression: React.FC<{ updateQuery: Function }> = ({ updateQuery }) => {
     const [expression, setExpression] = useState<string | number>('')
     const [label, setLabel] = useState<string | number>('')
+
     useEffect(() => {
-        updateQuery(expression,label)
+        updateQuery(expression, label)
         // eslint-disable-next-line react-hooks/exhaustive-deps
-    }, [expression,label])
+    }, [expression, label])
+
     return (
         <>
             <div className='spacer' />
@@ -31,8 +33,6 @@ export const PerformanceExpression: React.FC<{ updateQuery: Function }> = ({ upd
                     }}
                 />
             </SegmentSectionWithIcon>
-
         </>
     )
-
 }

--- a/src/datasources/perf-ds-react/PerformanceFilter.tsx
+++ b/src/datasources/perf-ds-react/PerformanceFilter.tsx
@@ -1,7 +1,7 @@
+import React, { useState, useEffect } from 'react'
 import { SelectableValue } from '@grafana/data';
 import { Segment, SegmentAsync, SegmentInput } from '@grafana/ui';
 import { SegmentSectionWithIcon } from 'components/SegmentSectionWithIcon';
-import React, { useState, useEffect } from 'react'
 
 export interface FilterItem {
     key: string,
@@ -11,14 +11,18 @@ export interface FilterItem {
     required: boolean,
     default: string
 }
+
 export interface FilterResponse extends FilterItem {
     parameter: FilterItem[]
 }
-export const PerformanceFilter: React.FC<{ updateQuery: Function, loadFilters: (query?: string | undefined) => Promise<Array<SelectableValue<FilterResponse>>> }> = ({ updateQuery, loadFilters }) => {
+
+export const PerformanceFilter: React.FC<{
+    updateQuery: Function,
+    loadFilters: (query?: string | undefined) => Promise<Array<SelectableValue<FilterResponse>>>
+}> = ({ updateQuery, loadFilters }) => {
 
     const [filter, setFilter] = useState<SelectableValue<FilterResponse>>({});
-
-    const [filterState, setFilterState] = useState<Record<string, {value: any,filter: any}>>({});
+    const [filterState, setFilterState] = useState<Record<string, {value: any, filter: any}>>({});
 
     const updateFilterState = (propertyName: string, value: {value: any, filter: any}) => {
         setFilterState({ ...filterState, [propertyName]: value })
@@ -28,6 +32,7 @@ export const PerformanceFilter: React.FC<{ updateQuery: Function, loadFilters: (
         updateQuery(filter,filterState);
         // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [filterState, filter])
+
     return (
         <>
             <div className='spacer' />
@@ -41,7 +46,7 @@ export const PerformanceFilter: React.FC<{ updateQuery: Function, loadFilters: (
                     }}
                 />
             </SegmentSectionWithIcon>
-            {filter?.parameter?.map((param, index) => {
+            { filter?.parameter?.map((param, index) => {
                 return (
                     <>
                         <div className='spacer' />
@@ -86,5 +91,4 @@ export const PerformanceFilter: React.FC<{ updateQuery: Function, loadFilters: (
             })}
         </>
     )
-
 }

--- a/src/datasources/perf-ds-react/PerformanceHelpers.ts
+++ b/src/datasources/perf-ds-react/PerformanceHelpers.ts
@@ -1,48 +1,78 @@
+import { ArrayVector, DataFrame, Field, FieldType } from "@grafana/data"
 import { FunctionFormatter } from "lib/function_formatter";
-import { SeriesResponse } from "./types";
+import { OnmsMeasurementsQueryResponse } from "./types";
 
-export const timestampsToDatapoints = (timestamps: [], columns: [{ values: number | null[] }], i: number, { start, end }: { start: number, end: number }) => {
+/**
+ * Convert QueryResponse data returned by OpenNMS Measurements Rest API to Grafana DataFrame format.
+ */
+export const measurementResponseToDataFrame =
+    (measurementData: OnmsMeasurementsQueryResponse, queryRefId?: string): DataFrame => {
 
-    let thereIsAtLeastOneValidValue;
-    let datapoints: [[string, string]] = [['', '']]
+    const { start, end, labels, columns, timestamps, metadata } = measurementData
 
-    for (let j = 0; j < timestamps.length; j++) {
-        if (timestamps[j] < start || timestamps[j] > end) {
-            continue;
-        }
-
-        let columnValue = columns[i].values[j];
-        if (columnValue === 'NaN') {
-            columnValue = null;
-        }
-
-        if (!thereIsAtLeastOneValidValue && !isNaN(columnValue)) {
-            thereIsAtLeastOneValidValue = true;
-        }
-        datapoints.push([columnValue, timestamps[j]]);
+    const dataFrame: DataFrame = {
+        name: '',
+        refId: queryRefId,
+        length: 0,
+        fields: []
     }
-    return { datapoints, thereIsAtLeastOneValidValue }
-}
 
-export const measurementResponseToGrafanaSeries = (response) => {
-    const { labels, columns, timestamps, metadata } = response.data;
+    if (!columns || !columns.length || !timestamps || !timestamps.length) {
+        return dataFrame
+    }
 
-    let series: SeriesResponse = { target: '', label: '', datapoints: [['', '']] }
+    // timestamps
+    let windowedTimestamps = [] as number[]
+    let startIndex = -1
+    let endIndex = timestamps.length - 1
+
+    for (let i = 0; i < timestamps.length; i++) {
+        const tsVal = timestamps[i]
+
+        if (end > 0 && tsVal > end) {
+            endIndex = i - 1
+            break
+        }
+
+        if (start === 0 || tsVal >= start) {
+            if (startIndex < 0) {
+                startIndex = i
+            }
+            windowedTimestamps.push(tsVal)
+        }
+    }
+
+    // no data or no data within the start/end timespan, return an empty DataFrame
+    if (windowedTimestamps.length === 0) {
+        return dataFrame
+    }
+
+    dataFrame.length = windowedTimestamps.length
+
+    dataFrame.fields.push({
+        name: 'Time',
+        type: FieldType.time,
+        config: {},
+        values: new ArrayVector<number>(windowedTimestamps)
+    } as Field)
+
     for (let i = 0; i < columns?.length; i++) {
-
-        const { datapoints, thereIsAtLeastOneValidValue } = timestampsToDatapoints(timestamps, columns, i, response.data);
-
         let label = metadata && metadata.resources ?
             FunctionFormatter.format(labels[i], metadata) :
             labels[i];
 
-        if (thereIsAtLeastOneValidValue) {
-            series = {
-                target: label,
-                label: labels[i],
-                datapoints: datapoints
-            }
-        }
+        const column = columns[i]
+        const windowedValues = column.values.slice(startIndex, endIndex + 1)
+
+        let field = {
+            name: label || 'Value',
+            type: FieldType.number, // number but actual data may be a string representing a number or "NaN"
+            config: {},
+            values: new ArrayVector<string | number | null>(windowedValues)
+        } as Field
+
+        dataFrame.fields.push(field)
     }
-    return series;
+
+    return dataFrame
 }

--- a/src/datasources/perf-ds-react/PerformanceStringProperty.tsx
+++ b/src/datasources/perf-ds-react/PerformanceStringProperty.tsx
@@ -1,15 +1,14 @@
+import React, { useState, useEffect } from 'react'
 import { Segment, SegmentAsync } from '@grafana/ui';
 import { SegmentSectionWithIcon } from 'components/SegmentSectionWithIcon';
-import React, { useState, useEffect } from 'react'
 import { PerformanceStringPropertyProps, PerformanceStringPropertyState } from './types';
-
-
 
 export const defaultPerformanceStringState = {
     node: { id: '' },
     resource: { id: '', stringPropertyAttributes: {} },
     stringProperty: { label: '', value: '' },
 }
+
 export const PerformanceStringProperty: React.FC<PerformanceStringPropertyProps> = ({
     updateQuery,
     loadNodes,
@@ -27,7 +26,7 @@ export const PerformanceStringProperty: React.FC<PerformanceStringPropertyProps>
             updateQuery(performanceState)
         }
     // eslint-disable-next-line react-hooks/exhaustive-deps
-    },[performanceState])
+    }, [performanceState])
 
     const stringPropertyAttributes = Object.entries(performanceState?.resource?.stringPropertyAttributes).map(([key, item]) => {
         return { label: key, value: key }
@@ -79,5 +78,4 @@ export const PerformanceStringProperty: React.FC<PerformanceStringPropertyProps>
             }
         </>
     )
-
 }

--- a/src/datasources/perf-ds-react/queries/interpolate.ts
+++ b/src/datasources/perf-ds-react/queries/interpolate.ts
@@ -1,0 +1,235 @@
+import { ScopedVars, VariableModel } from "@grafana/data"
+import { clone, isArray, isEmpty, isNil, isString } from "lodash"
+import { TemplateSrv } from "@grafana/runtime"
+import { ALL_SELECTION_VALUE } from 'constants/constants';
+
+export interface InterpolationArrayVariable {
+    name: string;
+    value: string[];
+}
+
+export interface InterpolationVariable {
+    name: string;
+    value: string | string[];
+}
+
+// Our version of @grafana/data VariableOption
+interface TemplateVariableOption {
+    value: string | string[];
+}
+
+// Our version of @grafana/data VariableWithOptions
+interface TemplateSrvVariable {
+    name: string;
+    current: TemplateVariableOption;
+    options: TemplateVariableOption[];
+}
+
+/**
+ * Collect any template variables that need to be interpolated, also taking into account scoped variables.
+ *
+ * Note, in latest Grafana, templateSrv.getVariables() items are VariableWithOptions
+ * We don't use all the properties of these, and they may not be present in earlier Grafana versions,
+ * so we use the above interface definitions to provide some typing information.
+ * See: https://github.com/grafana/grafana/blob/main/packages/grafana-data/src/types/templateVars.ts
+ */
+export const collectInterpolationVariables = (templateSrv: TemplateSrv, scopedVars: ScopedVars): InterpolationVariable[] => {
+    // Reformat the variables to work with our interpolate function
+    const variables = [] as InterpolationVariable[];
+
+    templateSrv.getVariables().forEach((templateVariable: VariableModel) => {
+        const variable = {
+            name: templateVariable.name,
+            value: [] as string[]
+        } as InterpolationArrayVariable
+
+        // If this templateVar exists in scopedVars, we need to look at the scoped values
+        if (scopedVars && !isNil(scopedVars[variable.name])) {
+            variable.value = [scopedVars[variable.name].value.toString()];
+        } else {
+            // TODO: templateSrv.getVariables() in Grafana 8.5 returns VariableModel[],
+            // VariableModel does NOT contain 'current' or 'current.value'
+            // But latest Grafana, 9.4.0, returns TypedVariableModel[], which is actually
+            // instances of DashboardVariableModel, which is SystemVariable<DashboardProps> which
+            // DOES contain 'current' and 'current.value'
+            const templateSrvVariable = (templateVariable as any) as TemplateSrvVariable
+            const currentValue = templateSrvVariable.current.value
+
+            if (isString(currentValue)) {
+                // If currentValue is a single-valued string
+                variable.value = [currentValue]
+            } else {
+                // If currentValue is a string[]
+                currentValue.forEach(value => {
+                    if (value === ALL_SELECTION_VALUE) {(
+                        templateSrvVariable.options
+                        .filter(o => o.value !== ALL_SELECTION_VALUE)
+                        .forEach(option => variable.value.push(isArray(option.value) ? (option.value as string[])[0] : option.value as string))
+                    )
+                    } else {
+                        variable.value.push(value);
+                    }
+                })
+            }
+        }
+
+        variables.push(variable);
+    })
+
+    return variables
+}
+
+const defaultContainsVariable = (value: any | undefined, variableName: string) => {
+    if (isNil(value) || isEmpty(value) || !isString(value)) {
+        return false;
+    }
+
+    return value.indexOf("$" + variableName) >= 0;
+}
+
+const defaultReplace = (value: any, variables: InterpolationVariable[]) => {
+    if (isNil(value) || isEmpty(value)) {
+        return value;
+    }
+
+    let interpolatedValue = value;
+
+    variables.forEach(variable => {
+        const regexVarName = "\\$" + variable.name.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+
+        interpolatedValue = interpolatedValue.replace(new RegExp(regexVarName, 'g'), variable.value);
+    })
+
+    return interpolatedValue;
+}
+
+const cartesianProductOfArrays = <T>(arrays: T[][]): T[][] => {
+    // Based on the code from http://stackoverflow.com/questions/15298912/
+    // javascript-generating-combinations-from-n-arrays-with-m-elements
+    const r: T[][] = []
+    const max = arrays.length - 1;
+
+    const helper = (arr: T[], i: number) => {
+        for (let j = 0, l = arrays[i].length; j < l; j++) {
+            const a = arr.slice(0); // clone arr
+            a.push(arrays[i][j]);
+
+            if (i === max) {
+                r.push(a);
+            } else {
+                helper(a, i + 1);
+            }
+        }
+    }
+
+    helper([], 0);
+    return r;
+}
+
+const cartesianProductOfVariables = (variables: InterpolationVariable[]) => {
+    // Collect the values from all of the variables
+    const allValues: string[][] = variables.map(v => Array.isArray(v.value) ? v.value : [v.value])
+
+    // Generate the cartesian product
+    const productOfAllValues = cartesianProductOfArrays<string>(allValues);
+
+    // Rebuild the variables
+    const productOfAllVariables = [] as InterpolationVariable[][];
+
+    productOfAllValues.forEach((rowOfValues: string[]) => {
+        const rowOfVariables = [] as InterpolationVariable[];
+
+        for (let i = 0, l = variables.length; i < l; i++) {
+            // Deep clone
+            var variable = JSON.parse(JSON.stringify(variables[i]));
+            variable.value = rowOfValues[i];
+            rowOfVariables.push(variable);
+        }
+
+        productOfAllVariables.push(rowOfVariables);
+    })
+
+    return productOfAllVariables
+}
+
+/**
+ * Replaces the source's attributes with the values of the referenced variables.
+ *
+ * If a referenced variable contains multiple values or if there are multiple referenced variables
+ * then we generate copies of the source with all of the possible permutations.
+ *
+ * See interpolate_spec.js for examples.
+ *
+ * T is actually going to be:
+ * - OnmsMeasurementsQuerySource for Attribute queries
+ * - OnmsMeasurementsQueryExpression for Expression queries
+ * - PerformanceQuery.filterState (just an object) for Filter queries
+ *
+ * @param object
+ *    the object to interpolate
+ * @param attributes
+ *    a list of attributes on a given object that should be checked for variables
+ * @param variables
+ *    a list of variables of the form [{name: 'varname', value: ['value1', 'value2']}, ...]
+ * @param callback
+ *    an optional callback made with the object after variable substitution has been performed
+ * @param containsVariable
+ *    optionally override the function used to determine if a string contains a reference to the named variable
+ * @param replace
+ *    optionally override the function used to substitute the variable reference in a string with the variables's value
+ * @returns an array of objects, if no substitutions were performed, the array will contain the original object
+ */
+export const interpolate = <T extends any>(object: T, attributes: string[],
+    interpolationVars: InterpolationVariable[],
+    callback: (src: T) => void = () => {}): T[] => {
+
+    // Add the index variable with a single value
+    const variablesWithIndex = clone(interpolationVars)
+    variablesWithIndex.push({ name: 'index', value: ['0'] })
+
+    // Collect the list of variables that are referenced by one or more of the keys
+    const referencedVariables = [] as InterpolationVariable[]
+
+    variablesWithIndex.forEach(variable => {
+        const isVariableReferenced = attributes.find(attribute => defaultContainsVariable(object[attribute], variable.name))
+
+        if (isVariableReferenced) {
+            referencedVariables.push(variable);
+        }
+    })
+
+    if (referencedVariables.length < 1) {
+        // No variables are referenced, nothing to substitute
+        callback(object)
+        return [object]
+    }
+
+    // Generate all possible permutations of the referenced variable's values
+    const productOfAllVariables = cartesianProductOfVariables(referencedVariables)
+
+    // Perform the required variable substitution
+    const objects = [] as T[];
+    let index = 0;
+
+    productOfAllVariables.forEach((rowOfReferencedVariables: InterpolationVariable[]) => {
+        // Update the value of the index variable to reflect the index of the row
+        rowOfReferencedVariables.forEach(variable => {
+            if (variable.name === 'index') {
+                variable.value = 'idx' + index;
+                index += 1;
+            }
+        })
+
+        const o = clone(object);
+
+        attributes.forEach(attribute => {
+            o[attribute] = defaultReplace(o[attribute], rowOfReferencedVariables);
+        });
+
+        callback(o);
+
+        objects.push(o);
+    })
+
+    return objects;
+}

--- a/src/datasources/perf-ds-react/queries/queryBuilder.ts
+++ b/src/datasources/perf-ds-react/queries/queryBuilder.ts
@@ -1,0 +1,147 @@
+import { isEmpty, isNil } from "lodash"
+import {
+    OnmsMeasurementsQueryRequest,
+    OnmsMeasurementsQueryExpression,
+    OnmsMeasurementsQueryFilter,
+    OnmsMeasurementsQueryFilterParam,
+    OnmsMeasurementsQuerySource,
+    PerformanceQuery
+} from '../types';
+
+export const buildPerformanceMeasurementQuery = (start: number, end: number, step: number, maxRows: number) => {
+    return {
+        start: start,
+        end: end,
+        step: step,
+        maxrows: maxRows,
+        relaxed: true, // enable relaxed mode, which allows for missing attributes
+        source: [] as any[],
+        expression: [] as any[],
+        filter: [] as any[]
+    } as OnmsMeasurementsQueryRequest
+}
+
+export const isValidMeasurementQuery = (query: OnmsMeasurementsQueryRequest) => {
+    const ok =
+        (query.source.length > 0 && query.source[0].attribute && query.source[0].resourceId) ||
+        (query.expression.length > 0 && query.expression[0].value) ||
+        (query.filter.length > 0 && query.filter[0].name && query.filter[0].parameter)
+
+    return ok
+}
+
+export const isValidAttributeTarget = (target: PerformanceQuery) => {
+    if (!target ||
+        !(target.attribute &&
+          target.attribute.attribute &&
+          target.attribute.resource.id &&
+          (target.attribute.node.id || target.attribute.node.label))) {
+        return false
+    }
+
+    return true
+}
+
+export const isValidExpressionTarget = (target: PerformanceQuery) => {
+    return (!target || !(target.label && target.expression)) ? false : true
+}
+
+export const isValidFilterTarget = (target: PerformanceQuery) => {
+    return (!target || !target.filter || !target.filter.name) ? false : true
+}
+
+export const buildAttributeQuerySource = (target: PerformanceQuery) => {
+    const source = {
+        label: target.attribute.label || target.attribute.attribute.name,
+        resourceId: target.attribute.resource.id.replace('node[', 'nodeSource['),
+        attribute: target.attribute.attribute.name,
+        ['fallback-attribute']: target.attribute.fallbackAttribute.name,
+        aggregation: target.attribute.aggregation?.label?.toUpperCase() || 'AVERAGE',
+        transient: false
+    } as OnmsMeasurementsQuerySource
+
+    return source;
+}
+
+export const buildExpressionQuery = (target: PerformanceQuery, index: number) => {
+    const expression = {
+        label: target.label || 'expression' + index,
+        value: target.expression,
+        transient: target.hide
+    } as OnmsMeasurementsQueryExpression
+
+    return expression
+}
+
+export const buildFilterQueryOLD = (target: PerformanceQuery) => {
+    const filter = [] as OnmsMeasurementsQueryFilterParam[]
+
+    // TODO: Interpolate the filter params
+
+    for (let [, item] of Object.entries(target.filterState)) {
+        const filterItem = item as { value: { value: string }, filter: { key: string } }
+        let value: any = filterItem.value
+        if (value.value) {
+            value = value.value
+        }
+        if (value) {
+            filter.push({ key: filterItem.filter.key, value })
+        }
+    }
+
+    return {
+        parameter: filter,
+        name: target.filter.name
+    } as OnmsMeasurementsQueryFilter
+}
+
+
+export const buildFilterQuery = (target: PerformanceQuery, interpolatedFilterParams: any[]) => {
+    // Shape of interpolatedFilterParams is various entries such as:
+    // {
+    //     "Input": {
+    //         value: "HeapUsageUsed",
+    //         filter: {
+    //             key: "inputColumn"
+    //             // default, description, required, etc.
+    //         }
+    //     },
+    //     "Output": {
+    //         value: "HeapUsageUsedPct",
+    //         filter: {
+    //             key: "outputColumn"
+    //         }
+    //     }
+    // }
+    // need to be converted to:
+    // [
+    //   {
+    //     key: "inputColumn",
+    //     value: "HeapUsageUsed"
+    //   },
+    //   {
+    //     key: "outputColumn",
+    //     value: "HeapUsageUsedPct"
+    //   },
+    // ...
+    // }
+
+    const filters = interpolatedFilterParams.map(filterParams => {
+        const parameters: OnmsMeasurementsQueryFilterParam[] = (
+            Object.entries(filterParams)
+            .filter(([, value]) => !isNil(value) && !isEmpty(value))
+            .map(([key, value]) => {
+                const v = value as any
+                return { key: v.filter?.key || '', value: v.value || '' } as OnmsMeasurementsQueryFilterParam
+            })
+            .filter(p => p.key && p.value)
+        )
+
+        return {
+            name: target.filter.name,
+            parameter: parameters
+        } as OnmsMeasurementsQueryFilter;
+    });
+
+    return filters
+}

--- a/src/datasources/perf-ds-react/queries/queryStringProperties.ts
+++ b/src/datasources/perf-ds-react/queries/queryStringProperties.ts
@@ -1,0 +1,241 @@
+import {
+    ArrayVector,
+    DataFrame,
+    DataQueryRequest,
+    DataQueryResponse,
+    DataQueryResponseData,
+    Field,
+    FieldType,
+    Vector
+} from "@grafana/data";
+import { TemplateSrv } from "@grafana/runtime"
+import { Client, ServerMetadata } from "opennms"
+import { ClientDelegate } from "../../../lib/client_delegate"
+import { SimpleOpenNMSRequest } from "../../../lib/utils"
+import {
+    DefinedStringPropertyQuery,
+    PerformanceQuery
+} from "./../types";
+
+interface RestResourceSelectQuery {
+    nodes: Set<string>;
+    nodeSubresources: Set<string>;
+    stringProperties: Set<string>;
+}
+
+interface RestResourceDTOCollection {
+    resource: RestResourceDTO[];
+}
+
+interface RestResourceDTOBase {
+    id: string;
+    label: string;
+}
+
+interface RestResourceDTO extends RestResourceDTOBase {
+    name: string;
+    children: RestResourceDTOCollection;
+    stringPropertyAttributes: Map<string,string>;
+}
+
+// constructs a single string valued data frame field
+const toStringField = (name: string, value: string): Field<string, Vector<string>> => {
+    return {
+        name,
+        type: FieldType.string,
+        config: {},
+        values: new ArrayVector<string>([value])
+    }
+}
+
+// constructs all data frame fields for a string property
+const toStringFields = (node: RestResourceDTOBase, resource: RestResourceDTOBase, key: string, value: string) => {
+    return [
+        toStringField('nodeId', node.id),
+        toStringField('nodeLabel', node.label),
+        toStringField('resourceId', resource.id),
+        toStringField('resourceLabel', resource.label),
+        toStringField(key, value)
+    ]
+}
+
+const isDefinedStringPropertyQuery = (q: PerformanceQuery | undefined) => {
+    const ps = q?.performanceState
+
+    return ps && ps.node.id && ps.resource.id && ps.stringProperty.value ? true : false
+}
+
+export const getDefinedStringPropertyQueries = (templateSrv: TemplateSrv, targets: PerformanceQuery[]) => {
+    const definedQueries: DefinedStringPropertyQuery[] = targets
+        .filter(q => !q.hide)
+        .filter(isDefinedStringPropertyQuery)
+        .map(q => {
+            return {
+                //...q,
+                // DataQuery fields
+                refId: q.refId,
+                hide: q.hide,
+                key: q.key,
+                queryType: q.queryType,
+                datasource: q.datasource,
+
+                // StringPropertyQuery fields
+                nodeId: templateSrv.replace('' + q.performanceState.node.id),
+                resourceId: templateSrv.replace(q.performanceState.resource.id),
+                stringProperty: q.performanceState.stringProperty.value
+            } as DefinedStringPropertyQuery
+        })
+
+    return definedQueries
+}
+
+const queryAllStringProperties = async (simpleRequest: SimpleOpenNMSRequest,
+    selection: RestResourceSelectQuery): Promise<DataQueryResponse> => {
+
+    const response = await simpleRequest.doOpenNMSRequest({
+        url: '/rest/resources/select',
+        method: 'GET',
+        params: {
+            nodes: Array.from(selection.nodes).join(','),
+            nodeSubresources: Array.from(selection.nodeSubresources).join(','),
+            stringProperties: Array.from(selection.stringProperties).join(',')
+        }
+    })
+
+    const responseData = response.data as RestResourceDTO[];
+
+    const fieldSets =
+        responseData.flatMap(node =>
+            node.children.resource.flatMap(resource =>
+                //Object.entries<string>(resource.stringPropertyAttributes).flatMap(([key, value]) => {
+                Array.from(resource.stringPropertyAttributes.entries()).flatMap(([key, value]) => {
+                    return {
+                        fields: toStringFields(node, resource, key, value)
+                    }
+                })
+            )
+        )
+
+    const dataFrames =
+        fieldSets.map(f => {
+            return {
+                fields: f.fields,
+                length: f.fields.length
+            } as DataFrame
+        })
+
+    return {
+        data: dataFrames
+    } as DataQueryResponse
+}
+
+const queryStringPropertiesForAllNodesInBulk = async (
+    simpleRequest: SimpleOpenNMSRequest,
+    definedQueries: DefinedStringPropertyQuery[]): Promise<DataQueryResponse> => {
+
+    // send a single request that selects all nodes, subresources, and string properties
+    const selection =
+        definedQueries.reduce<RestResourceSelectQuery>(
+            (accu, query) => {
+                accu.nodes.add(query.nodeId)
+                accu.nodeSubresources.add(query.resourceId)
+                accu.stringProperties.add(query.stringProperty)
+                return accu
+            },
+        { nodes: new Set(), nodeSubresources: new Set(), stringProperties: new Set() })
+
+    const response: DataQueryResponse = await queryAllStringProperties(simpleRequest, selection)
+
+    return response
+}
+
+const extractStringProperties = (
+    query: DefinedStringPropertyQuery,
+    resource: RestResourceDTO,
+    node?: RestResourceDTO): DataFrame[] /*DataQueryResponseData[]*/ => {
+
+    const matchingKeys =
+        Object.keys(resource.stringPropertyAttributes)
+        .filter(key => key === query.stringProperty)
+
+    const dataFrames = matchingKeys.map(key => {
+        return {
+            refId: query.refId,
+            fields: [
+                toStringField('nodeId', query.nodeId),
+                toStringField('nodeLabel', node ? node.label : query.nodeId),
+                toStringField('resourceId', query.resourceId),
+                toStringField('resourceLabel', resource.label),
+                toStringField(key, resource.stringPropertyAttributes[key])
+            ],
+            length: 5
+        } as DataFrame
+    })
+
+    return dataFrames
+}
+
+const queryStringPropertiesOfNode = async (
+    simpleRequest: SimpleOpenNMSRequest,
+    nodeId: string,
+    queries: DefinedStringPropertyQuery[]): Promise<DataQueryResponseData[]> => {
+
+    const response = await simpleRequest.doOpenNMSRequest({
+        url: '/rest/resources/fornode/' + encodeURIComponent(nodeId),
+        method: 'GET'
+    })
+
+    const nodeDto = response.data as RestResourceDTO;
+
+    const data =
+        queries.flatMap(query => {
+            return nodeDto.children.resource
+                .filter(resource => resource.id.endsWith(`.${query.resourceId}`))
+                .flatMap(resource => extractStringProperties(query, resource, nodeDto))
+        })
+
+    return data
+}
+
+const queryStringPropertiesForEachNodeSeparately = async (
+    simpleRequest: SimpleOpenNMSRequest,
+    definedQueries: DefinedStringPropertyQuery[]): Promise<DataQueryResponse> => {
+
+    const groupedByNodeId = definedQueries.reduce<{ [key: string]: DefinedStringPropertyQuery[] }>(
+        (accu, query) => {
+            (accu[query.nodeId] = accu[query.nodeId] || []).push(query)
+            return accu
+    }, {})
+
+    // send a request for each node separately...
+    const datas: Array<Promise<DataQueryResponseData[]>> =
+        Object.keys(groupedByNodeId).map((nodeId) => {
+            const queries = groupedByNodeId[nodeId]
+            return queryStringPropertiesOfNode(simpleRequest, nodeId, queries)
+        })
+
+    // ... and then combine all results into a single DataQueryResponse
+    return Promise.all(datas).then(datas => {
+        return {
+            data: datas.flatMap(x => x)
+        }
+    })
+}
+
+export const queryStringProperties = async (
+    clientDelegate: ClientDelegate,
+    simpleRequest: SimpleOpenNMSRequest,
+    templateSrv: TemplateSrv,
+    request: DataQueryRequest<PerformanceQuery>): Promise<DataQueryResponse> => {
+
+    const definedQueries = getDefinedStringPropertyQueries(templateSrv, request.targets)
+
+    const client: Client = await clientDelegate.getClientWithMetadata()
+    const metadata: ServerMetadata = client.http.server.metadata;
+
+    if (metadata.selectPartialResources()) {
+        return queryStringPropertiesForAllNodesInBulk(simpleRequest, definedQueries)
+    } else {
+        return queryStringPropertiesForEachNodeSeparately(simpleRequest, definedQueries)
+    }
+}

--- a/src/datasources/perf-ds-react/types.ts
+++ b/src/datasources/perf-ds-react/types.ts
@@ -26,6 +26,86 @@ export interface PerformanceQueryRequest<T extends DataQuery> extends DataQueryR
   queryText: string;
 }
 
+export interface StringPropertyQuery extends DataQuery {
+    type?: string;
+    nodeId?: string;
+    resourceId?: string;
+    stringProperty?: string;
+}
+
+export type DefinedStringPropertyQuery = Required<StringPropertyQuery>
+
+export interface OnmsMeasurementsQuerySource {
+  label: string;
+  resourceId: string;
+  attribute: string;
+  ['fallback-attribute']: string;
+  aggregation: string;  // should be 'AVERAGE', 'MIN', 'MAX' or 'LAST'
+  transient: boolean;
+  nodeId?: string; // this may be added dynamically
+}
+
+export interface OnmsMeasurementsQueryExpression {
+  label: string;
+  value: string;  // this is the jexl or similar expression
+  transient: boolean;
+}
+
+export interface OnmsMeasurementsQueryFilterParam {
+    key: string;
+    value: string | { value: string }
+}
+
+export interface OnmsMeasurementsQueryFilter {
+  name: string;
+  parameter: OnmsMeasurementsQueryFilterParam[]
+}
+
+// See features/measurements/api, package org.opennms.netmgt.measurements.model.QueryRequest
+export interface OnmsMeasurementsQueryRequest {
+  start: number;
+  end: number;
+  step: number;
+  relaxed: boolean; // enable relaxed mode, which allows for missing attributes
+  maxrows: number;
+  source: OnmsMeasurementsQuerySource[];
+  expression: OnmsMeasurementsQueryExpression[];
+  filter: OnmsMeasurementsQueryFilter[];
+}
+
+export interface OnmsMeasurementsQueryNode {
+  id: number;
+  ["foreign-source"]: string;
+  ["foreign-id"]: string;
+  label: string;
+}
+
+export interface OnmsMeasurementsQueryResource {
+  id: string;
+  ["parent-id"]: string;
+  label: string;
+  name: string;
+  ["node-id"]: number;
+  node: OnmsMeasurementsQueryNode;
+}
+
+export interface OnmsMeasurementsQueryMetadata {
+  resources: Array<{ resource: OnmsMeasurementsQueryResource }>;
+  nodes: Array<{ node: OnmsMeasurementsQueryNode }>;
+}
+
+// See features/measurements/api, package org.opennms.netmgt.measurements.model.QueryResponse
+export interface OnmsMeasurementsQueryResponse {
+  step: number;
+  start: number;
+  end: number;
+  timestamps: number[];
+  labels: string[];
+  columns: Array<{ values: Array<string | number | null> }>;  // TODO: Is this returned as string or number in Json???
+  constants: Array<{ key: string, value: string }>;
+  metadata: OnmsMeasurementsQueryMetadata;
+}
+
 export interface QuickSelect {
  label?: string, 
  value?: number 
@@ -35,12 +115,6 @@ export type PerformanceQueryEditorProps = QueryEditorProps<PerformanceDataSource
 
 export interface OnmsQueryResultMeta extends QueryResultMeta {
     entity_metadata: any[];
-}
-
-export interface SeriesResponse {
-    target: string,
-    label: string,
-    datapoints: [[string, string]]
 }
 
 export interface PerformanceStringPropertyProps {

--- a/src/panels/alarm-table-react/hooks/useAlarmHelmProperties.ts
+++ b/src/panels/alarm-table-react/hooks/useAlarmHelmProperties.ts
@@ -12,7 +12,6 @@ export const useAlarmHelmProperties = (oldProperties, alarmTable) => {
         const totalRows = filteredProps.fields[0].values.length
         const rowsPerPage = Number(alarmTable.alarmTablePaging.rowsPerPage)
         if (filteredProps) {
-
             // Allow background color for severity column.
             if (alarmTable?.alarmTableAlarms?.styleWithSeverity?.value === 1) {
                 filteredProps.fields = filteredProps.fields.map((field) => {


### PR DESCRIPTION
HELM-331 Convert Performance Datasource to React

Continued work on converting the Performance Datasource to React. This is not complete or fully tested, so it's still a work in progress, but continued work will probably need all/most of this code. You can for example perform attribute queries, including with a node template variable, then apply a filter query such as quantile.

- added Typescript interfaces for many of the data structures

- various fixes to Attribute queries and some work on using template variables

- got Filter queries working

- pulled in and refactored code for String Property queries, not fully tested

- added and refactored variable interpolation code, not fully tested

- added code to convert OpenNMS performance measurement data to Grafana DataFrame format, removed previous code

- SwitchBox, add `className` to props to allow additional styling of enclosed Switch


# External References

* JIRA (Issue Tracker): https://opennms.atlassian.net/browse/HELM-331
* Continuous Integration: [CircleCI](https://circleci.com/gh/OpenNMS/opennms-helm)
