### PR TITLE
HELM-331: PerfDS React, various query fixes

### DIFF
--- a/src/datasources/perf-ds-react/PerformanceAttribute.tsx
+++ b/src/datasources/perf-ds-react/PerformanceAttribute.tsx
@@ -6,28 +6,14 @@ import {
 } from '@grafana/ui'
 import { SegmentSectionWithIcon } from 'components/SegmentSectionWithIcon';
 import React, { useState, useEffect } from 'react'
+import { PerformanceAttributeItemState, PerformanceAttributeState } from './types'
 
 export interface PerformanceAttributesProps {
+    performanceAttributeState: PerformanceAttributeState;
     updateQuery: Function;
-    loadNodes: (query?: string | undefined) => Promise<Array<SelectableValue<PerformanceAttributeStateNode>>>;
+    loadNodes: (query?: string | undefined) => Promise<Array<SelectableValue<PerformanceAttributeItemState>>>;
     loadResourcesByNode: Function;
     loadAttributesByResourceAndNode: Function;
-}
-
-export interface PerformanceAttributeStateNode {
-    id: string;
-    label?: string;
-}
-
-export interface PerformanceAttributeState {
-     // this may be an OnmsNode object, or else just an id and/or label
-    node: PerformanceAttributeStateNode;
-    resource: { id: string };
-    attribute: { name: string };
-    subAttribute: string | number;
-    fallbackAttribute: { name: string };
-    aggregation: { label?: string };
-    label: string;
 }
 
 export const defaultPerformanceState: PerformanceAttributeState = {
@@ -41,20 +27,24 @@ export const defaultPerformanceState: PerformanceAttributeState = {
 }
 
 export const PerformanceAttribute: React.FC<PerformanceAttributesProps> = ({
+    performanceAttributeState,
     updateQuery,
     loadNodes,
     loadResourcesByNode,
     loadAttributesByResourceAndNode
 }) => {
 
-    const [performanceState, setPerformanceState] = useState<PerformanceAttributeState>(defaultPerformanceState)
+    const [performanceState, setPerformanceState] = useState<PerformanceAttributeState>(performanceAttributeState)
 
     useEffect(() => {
-        if (performanceState.attribute && (performanceState.node.id || performanceState.node.label) && performanceState.resource.id) {
+        if (performanceState &&
+            performanceState.attribute &&
+            (performanceState.node.id || performanceState.node.label) &&
+            (performanceState.resource.id || performanceState.resource.label)) {
             updateQuery(performanceState);
         }
     // eslint-disable-next-line react-hooks/exhaustive-deps
-    },[performanceState])
+    }, [performanceState])
 
     const setPerformanceStateProperty = (propertyName: string, propertyValue: unknown) => {
         setPerformanceState({...performanceState, [propertyName]: propertyValue})
@@ -84,14 +74,15 @@ export const PerformanceAttribute: React.FC<PerformanceAttributesProps> = ({
                         placeholder='Select Resource'
                         loadOptions={() => loadResourcesByNode(performanceState?.node?.id || performanceState?.node?.label)}
                         onChange={(value) => {
-                            setPerformanceStateProperty('resource',value);
+                            setPerformanceStateProperty('resource', value);
                         }}
                     />
                 </SegmentSectionWithIcon>
             }
             <div className='spacer' />
             {
-                (performanceState?.node?.id || performanceState?.node?.label) && performanceState?.resource?.id &&
+                (performanceState?.node?.id || performanceState?.node?.label) &&
+                (performanceState?.resource?.id || performanceState?.resource?.label) &&
                 <>
                     <SegmentSectionWithIcon label='Attribute' icon='tag'>
                         <SegmentAsync
@@ -99,17 +90,17 @@ export const PerformanceAttribute: React.FC<PerformanceAttributesProps> = ({
                             placeholder='Select Attribute'
                             loadOptions={() => loadAttributesByResourceAndNode(performanceState?.node, performanceState?.resource)}
                             onChange={(value) => {
-                                setPerformanceStateProperty('attribute',value)
+                                setPerformanceStateProperty('attribute', value)
                             }}
                         />
                     </SegmentSectionWithIcon>
                     <div className='spacer' />
                     <SegmentSectionWithIcon label='Sub-Attribute' icon='flash'>
                         <SegmentInput
-                            value={performanceState?.subAttribute}
+                            value={performanceState?.subAttribute || ''}
                             placeholder='Sub-Attribute'
                             onChange={(value) => {
-                                setPerformanceStateProperty('subAttribute',value)
+                                setPerformanceStateProperty('subAttribute', value)
                             }}
                         />
                     </SegmentSectionWithIcon>
@@ -120,7 +111,7 @@ export const PerformanceAttribute: React.FC<PerformanceAttributesProps> = ({
                             placeholder='Fallback Attribute'
                             loadOptions={() => loadAttributesByResourceAndNode(performanceState?.node, performanceState?.resource)}
                             onChange={(value) => {
-                                setPerformanceStateProperty('fallbackAttribute',value)
+                                setPerformanceStateProperty('fallbackAttribute', value)
                             }}
                         />
                     </SegmentSectionWithIcon>
@@ -131,7 +122,7 @@ export const PerformanceAttribute: React.FC<PerformanceAttributesProps> = ({
                             placeholder='Aggregation'
                             options={[{ label: 'Average' }, { label: 'Min' }, { label: 'Max' }, { label: 'Last' }]}
                             onChange={(value) => {
-                                setPerformanceStateProperty('aggregation',value)
+                                setPerformanceStateProperty('aggregation', value)
                             }}
                         />
                     </SegmentSectionWithIcon>
@@ -142,7 +133,7 @@ export const PerformanceAttribute: React.FC<PerformanceAttributesProps> = ({
                 <SegmentInput
                     value={performanceState?.label}
                     placeholder='Series Label'
-                    onChange={(value) => setPerformanceStateProperty('label',value)}
+                    onChange={(value) => setPerformanceStateProperty('label', value)}
                 />
             </SegmentSectionWithIcon>
         </>

--- a/src/datasources/perf-ds-react/PerformanceDataSource.tsx
+++ b/src/datasources/perf-ds-react/PerformanceDataSource.tsx
@@ -1,5 +1,4 @@
 import { DataFrame, DataQueryResponse, DataSourceApi, DataSourceInstanceSettings } from "@grafana/data";
-import { isNil } from 'lodash'
 import { ClientDelegate } from "lib/client_delegate";
 import { SimpleOpenNMSRequest } from "lib/utils";
 import { PerformanceTypeOptions } from "./constants";
@@ -47,8 +46,9 @@ export class PerformanceDataSource extends DataSourceApi<PerformanceQuery> {
         const activeTargets = targets.filter(t => !t.hide)
 
         const totalStrings = activeTargets.filter((t) =>
-            !isNil(t.performanceType.value) &&
-            t.performanceType.value === PerformanceTypeOptions.StringProperty.value && t.performanceState?.stringProperty?.value)
+            t.performanceType.value &&
+            t.performanceType.value === PerformanceTypeOptions.StringProperty.value &&
+            t.performanceState?.stringProperty?.value)
         let typeOfQuery = 'normal'
 
         if (totalStrings.length > 0 && totalStrings.length === activeTargets.length) {

--- a/src/datasources/perf-ds-react/PerformanceDataSource.tsx
+++ b/src/datasources/perf-ds-react/PerformanceDataSource.tsx
@@ -1,10 +1,14 @@
 import { DataFrame, DataQueryResponse, DataSourceApi, DataSourceInstanceSettings } from "@grafana/data";
+import { isNil } from 'lodash'
 import { ClientDelegate } from "lib/client_delegate";
 import { SimpleOpenNMSRequest } from "lib/utils";
 import { PerformanceTypeOptions } from "./constants";
 import { measurementResponseToDataFrame } from "./PerformanceHelpers";
 import {
+    OnmsMeasurementsQueryRequest,
+    OnmsMeasurementsQueryResponse,
     OnmsMeasurementsQuerySource,
+    OnmsResourceDto,
     PerformanceDataSourceOptions,
     PerformanceQuery,
     PerformanceQueryRequest
@@ -15,6 +19,7 @@ import {
     buildExpressionQuery,
     buildFilterQuery,
     buildPerformanceMeasurementQuery,
+    getRemoteResourceId,
     isValidAttributeTarget,
     isValidExpressionTarget,
     isValidFilterTarget,
@@ -39,13 +44,16 @@ export class PerformanceDataSource extends DataSourceApi<PerformanceQuery> {
     }
 
     isQueryValidStringPropertySearch = (targets: PerformanceQuery[]) => {
-        const totalStrings = targets.filter((d) =>
-            d.performanceType.value === PerformanceTypeOptions.StringProperty.value && d.performanceState?.stringProperty?.value)
+        const activeTargets = targets.filter(t => !t.hide)
+
+        const totalStrings = activeTargets.filter((t) =>
+            !isNil(t.performanceType.value) &&
+            t.performanceType.value === PerformanceTypeOptions.StringProperty.value && t.performanceState?.stringProperty?.value)
         let typeOfQuery = 'normal'
 
-        if (totalStrings.length > 0 && totalStrings.length === targets.length) {
+        if (totalStrings.length > 0 && totalStrings.length === activeTargets.length) {
             typeOfQuery = 'string'
-        } else if (totalStrings.length > 0 && totalStrings.length < targets.length) {
+        } else if (totalStrings.length > 0 && totalStrings.length < activeTargets.length) {
             typeOfQuery = 'invalid'
         }
         return typeOfQuery;
@@ -66,7 +74,6 @@ export class PerformanceDataSource extends DataSourceApi<PerformanceQuery> {
 
         const maxDataPoints = options.maxDataPoints || 300;
         const intervalMs = options.intervalMs || 60 * 1000;
-
         const start = options.range.from.valueOf();
         const end = options.range.to.valueOf();
         let step = Math.floor((end - start) / maxDataPoints);
@@ -86,69 +93,71 @@ export class PerformanceDataSource extends DataSourceApi<PerformanceQuery> {
             if (target.performanceType?.value === PerformanceTypeOptions.Attribute.value) {
                 if (isValidAttributeTarget(target)) {
                     const source = buildAttributeQuerySource(target);
-
                     const interpolationVars = collectInterpolationVariables(this.templateSrv, options.scopedVars)
                     const attributes = ['nodeId', 'resourceId', 'attribute', 'datasource', 'label']
 
                     const callback = (interpolatedSource: OnmsMeasurementsQuerySource) => {
                         if (interpolatedSource.nodeId) {
                             // Calculate the effective resource id after the interpolation
-                            interpolatedSource.resourceId = this.getRemoteResourceId(interpolatedSource.nodeId, interpolatedSource.resourceId);
+                            interpolatedSource.resourceId = getRemoteResourceId(interpolatedSource.nodeId, interpolatedSource.resourceId);
+                            // remove nodeId since it should not be part of the Rest API request payload
                             delete interpolatedSource.nodeId;
                         }
                     }
 
                     const sources = interpolate(source, attributes, interpolationVars, callback)
-                    query.source = sources
+                    if (query.source && query.source.length > 0) {
+                        query.source = query.source.concat(sources)
+                    } else {
+                        query.source = sources
+                    }
                     labels = query.source.map(s => s.label)
                 }
             } else if (target.performanceType?.value === PerformanceTypeOptions.Expression.value) {
                 if (isValidExpressionTarget(target)) {
                     const expression = buildExpressionQuery(target, i);
-
                     const interpolationVars = collectInterpolationVariables(this.templateSrv, options.scopedVars)
                     const attributes = ['value', 'label']
 
                     const expressions = interpolate(expression, attributes, interpolationVars)
-                    query.expression = expressions
+                    if (query.expression && query.expression.length > 0) {
+                        query.expression = query.expression.concat(expressions)
+                    } else {
+                        query.expression = expressions
+                    }
 
                     labels = query.expression.map(e => e.label)
                 }
             } else if (target.performanceType?.value === PerformanceTypeOptions.Filter.value) {
                 if (isValidFilterTarget(target)) {
                     const interpolationVars = collectInterpolationVariables(this.templateSrv, options.scopedVars)
-
                     const attributes = Object.keys(target.filterState)
                     const interpolatedFilterParams = interpolate(target.filterState, attributes, interpolationVars)
-
                     const filters = buildFilterQuery(target, interpolatedFilterParams)
 
                     // Only add the filter attribute to the query when one or more filters are specified since
                     // OpenNMS versions before 17.0.0 do not support it
                     if (filters.length > 0) {
-                        if (!query.filter) {
-                            query.filter = filters;
-                        } else {
+                        if (query.filter && query.filter.length > 0) {
                             query.filter = query.filter.concat(filters);
+                        } else {
+                            query.filter = filters;
                         }
                     }
                 }
             }
 
             if (isValidMeasurementQuery(query)) {
-                const response = await this.simpleRequest.doOpenNMSRequest({
-                    url: '/rest/measurements',
-                    data: query,
-                    method: 'POST',
-                    headers: { 'Content-Type': 'application/json' }
-                });
+                const responseData = await this.doMeasuremmentQuery(query)
 
-                try {
-                    // convert to DataFrame format
-                    const dataFrame = measurementResponseToDataFrame(response.data, target.refId)
-                    dataFrames.push(dataFrame)
-                } catch (e) {
-                    console.error(e);
+                if (responseData) {
+                    try {
+                        // convert to DataFrame format
+                        const dataFrame = measurementResponseToDataFrame(responseData, target.refId)
+                        dataFrames.push(dataFrame)
+                    } catch (e) {
+                        console.error(e);
+                    }
                 }
             }
         }
@@ -164,8 +173,8 @@ export class PerformanceDataSource extends DataSourceApi<PerformanceQuery> {
 
     async testDatasource(): Promise<any> {
         console.log('Testing the data source!');
-        try {
 
+        try {
             const metadata = await this.client.getClientWithMetadata();
             console.log('Testing the data source1!', metadata);
         } catch (e) {
@@ -174,9 +183,35 @@ export class PerformanceDataSource extends DataSourceApi<PerformanceQuery> {
         return { status: 'success', message: 'Success' }
     }
 
-    getRemoteResourceId(nodeId: string, resourceId: string) {
-        const prefix = nodeId.indexOf(':') >= 0 ? 'nodeSource' : 'node'
+    async doMeasuremmentQuery(query: OnmsMeasurementsQueryRequest) {
+        const response = await this.simpleRequest.doOpenNMSRequest({
+            url: '/rest/measurements',
+            data: query,
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' }
+        });
 
-        return `${prefix}[${nodeId}].${resourceId}`
+        return response && response.data ? response.data as OnmsMeasurementsQueryResponse : null
+    }
+
+    async doResourcesRequest(resourceId: string) {
+        const response = await this.simpleRequest.doOpenNMSRequest({
+            url: '/rest/resources/' + encodeURIComponent(resourceId),
+            method: 'GET',
+            params: {
+                depth: -1
+            }
+        })
+
+        return response && response.data ? response.data as OnmsResourceDto : null
+    }
+
+    async doResourcesForNodeRequest(nodeId: string) {
+        const response = await this.simpleRequest.doOpenNMSRequest({
+            url: '/rest/resources/fornode/' + encodeURIComponent(nodeId),
+            method: 'GET'
+        })
+
+        return response && response.data ? response.data as OnmsResourceDto : null
     }
 }

--- a/src/datasources/perf-ds-react/PerformanceExpression.tsx
+++ b/src/datasources/perf-ds-react/PerformanceExpression.tsx
@@ -1,10 +1,16 @@
 import React, { useState, useEffect } from 'react'
 import { SegmentInput } from '@grafana/ui';
 import { SegmentSectionWithIcon } from 'components/SegmentSectionWithIcon';
+import { PerformanceQuery } from './types'
 
-export const PerformanceExpression: React.FC<{ updateQuery: Function }> = ({ updateQuery }) => {
-    const [expression, setExpression] = useState<string | number>('')
-    const [label, setLabel] = useState<string | number>('')
+export interface PerformanceExpressionProps {
+    query: PerformanceQuery;
+    updateQuery: Function;
+}
+
+export const PerformanceExpression: React.FC<PerformanceExpressionProps> = ({ query, updateQuery }) => {
+    const [expression, setExpression] = useState<string | number>(query.expression || '')
+    const [label, setLabel] = useState<string | number>(query.label || '')
 
     useEffect(() => {
         updateQuery(expression, label)
@@ -19,6 +25,9 @@ export const PerformanceExpression: React.FC<{ updateQuery: Function }> = ({ upd
                     value={expression}
                     placeholder='series expression'
                     onChange={(value) => {
+                        if (!label) {
+                            setLabel('expression' + query.refId)
+                        }
                         setExpression(value);
                     }}
                 />

--- a/src/datasources/perf-ds-react/PerformanceFilter.tsx
+++ b/src/datasources/perf-ds-react/PerformanceFilter.tsx
@@ -2,6 +2,7 @@ import React, { useState, useEffect } from 'react'
 import { SelectableValue } from '@grafana/data';
 import { Segment, SegmentAsync, SegmentInput } from '@grafana/ui';
 import { SegmentSectionWithIcon } from 'components/SegmentSectionWithIcon';
+import { PerformanceQuery } from './types'
 
 export interface FilterItem {
     key: string,
@@ -16,11 +17,14 @@ export interface FilterResponse extends FilterItem {
     parameter: FilterItem[]
 }
 
-export const PerformanceFilter: React.FC<{
-    updateQuery: Function,
-    loadFilters: (query?: string | undefined) => Promise<Array<SelectableValue<FilterResponse>>>
-}> = ({ updateQuery, loadFilters }) => {
+export interface PerformanceFilterProps {
+    query: PerformanceQuery;
+    updateQuery: Function;
+    loadFilters: (query?: string | undefined) => Promise<Array<SelectableValue<FilterResponse>>>;
+}
 
+export const PerformanceFilter: React.FC<PerformanceFilterProps> = ({ query, updateQuery, loadFilters }) => {
+    // TODO: Initialize these from 'query' prop
     const [filter, setFilter] = useState<SelectableValue<FilterResponse>>({});
     const [filterState, setFilterState] = useState<Record<string, {value: any, filter: any}>>({});
 
@@ -29,7 +33,7 @@ export const PerformanceFilter: React.FC<{
     }
 
     useEffect(() => {
-        updateQuery(filter,filterState);
+        updateQuery(filter, filterState);
         // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [filterState, filter])
 

--- a/src/datasources/perf-ds-react/constants.ts
+++ b/src/datasources/perf-ds-react/constants.ts
@@ -1,7 +1,7 @@
 
 export const PerformanceTypeOptions = {
-    Attribute: {label:'Attribute',value:1},
-    Expression: {label: 'Expression', value:2},
-    Filter: {label: 'Filter', value:3},
-    StringProperty: {label: 'String Property', value:4},
+    Attribute: { label: 'Attribute', value: 1 },
+    Expression: { label: 'Expression', value: 2 },
+    Filter: { label: 'Filter', value: 3 },
+    StringProperty: { label: 'String Property', value: 4 },
 }

--- a/src/datasources/perf-ds-react/queries/interpolate.ts
+++ b/src/datasources/perf-ds-react/queries/interpolate.ts
@@ -33,7 +33,7 @@ interface TemplateSrvVariable {
  * so we use the above interface definitions to provide some typing information.
  * See: https://github.com/grafana/grafana/blob/main/packages/grafana-data/src/types/templateVars.ts
  */
-export const collectInterpolationVariables = (templateSrv: TemplateSrv, scopedVars: ScopedVars): InterpolationVariable[] => {
+export const collectInterpolationVariables = (templateSrv: TemplateSrv, scopedVars?: ScopedVars): InterpolationVariable[] => {
     // Reformat the variables to work with our interpolate function
     const variables = [] as InterpolationVariable[];
 


### PR DESCRIPTION
# HELM-331: Performance Datasource Fixes

- fix variable interpolation for node and resource in Attribute queries
- Query Editor, get initial state from existing state (passed in props)
- encapsulate and provide strong typing for API requests
- check whether queries are hidden, filter them out before sending via API
- more comprehensive check for valid Filter queries, don't send to API if invalid
- ensure query targets added or concatenated as arrays to existing query
- various other fixes


# External References

* JIRA (Issue Tracker): [http://issues.opennms.org/browse/${JIRA-ISSUE-NUMBER}](https://opennms.atlassian.net/browse/HELM-331)
* Continuous Integration: [CircleCI](https://circleci.com/gh/OpenNMS/opennms-helm)
