### PR TITLE
HELM-302: Datasource and query editor help

### DIFF
--- a/package.json
+++ b/package.json
@@ -94,8 +94,8 @@
     "xlsx": "^0.18.5"
   },
   "scripts": {
-    "build": "webpack -c ./.config/webpack/webpack.config.ts --env production",
-    "dev": "webpack -c ./.config/webpack/webpack.config.ts --env development",
+    "build": "webpack -c ./webpack.config.ts --env production",
+    "dev": "webpack -c ./webpack.config.ts --env development",
     "docs": "antora --stacktrace generate local-site.yml",
     "e2e": "yarn cypress install && yarn grafana-e2e run",
     "e2e:update": "yarn cypress install && yarn grafana-e2e run --update-screenshots",
@@ -109,6 +109,6 @@
     "test:watch": "jest --watch --onlyChanged",
     "typecheck": "tsc --noEmit",
     "validate-xrefs": "antora --generator @antora/xref-validator local-site.yml",
-    "watch": "webpack -w -c ./.config/webpack/webpack.config.ts --env development"
+    "watch": "webpack -w -c ./webpack.config.ts --env development"
   }
 }

--- a/src/datasources/entity-ds/EntityQueryEditorHelp.tsx
+++ b/src/datasources/entity-ds/EntityQueryEditorHelp.tsx
@@ -1,0 +1,12 @@
+import React from 'react'
+import { QueryEditorHelpProps } from '@grafana/data'
+import { EntityQuery } from './types'
+
+export const EntityQueryEditorHelp: React.FC<QueryEditorHelpProps<EntityQuery>> = () => {
+
+  return (
+    <div>
+      Help for Entity Data source queries
+    </div>
+  )
+}

--- a/src/datasources/entity-ds/help-README.md
+++ b/src/datasources/entity-ds/help-README.md
@@ -1,0 +1,1 @@
+# OpenNMS plugin for Grafana: Entity Data source

--- a/src/datasources/entity-ds/module.ts
+++ b/src/datasources/entity-ds/module.ts
@@ -1,10 +1,12 @@
-import { DataSourcePlugin } from '@grafana/data';
-import { EntityConfigEditor } from './EntityConfigEditor';
-import { EntityDataSource } from './EntityDataSource';
-import { EntityQueryEditor } from './EntityQueryEditor';
-import { EntityDataSourceOptions, EntityQuery } from './types';
+import { DataSourcePlugin } from '@grafana/data'
+import { EntityConfigEditor } from './EntityConfigEditor'
+import { EntityDataSource } from './EntityDataSource'
+import { EntityQueryEditor } from './EntityQueryEditor'
+import { EntityQueryEditorHelp } from './EntityQueryEditorHelp'
+import { EntityDataSourceOptions, EntityQuery } from './types'
 
 
 export const plugin = new DataSourcePlugin<EntityDataSource, EntityQuery, EntityDataSourceOptions>(EntityDataSource)
-.setConfigEditor(EntityConfigEditor)
-.setQueryEditor(EntityQueryEditor);
+  .setConfigEditor(EntityConfigEditor)
+  .setQueryEditor(EntityQueryEditor)
+  .setQueryEditorHelp(EntityQueryEditorHelp);

--- a/src/datasources/flow-ds/FlowQueryEditorHelp.tsx
+++ b/src/datasources/flow-ds/FlowQueryEditorHelp.tsx
@@ -1,0 +1,12 @@
+import React from 'react'
+import { QueryEditorHelpProps } from '@grafana/data'
+import { FlowQuery } from './types'
+
+export const FlowQueryEditorHelp: React.FC<QueryEditorHelpProps<FlowQuery>> = () => {
+
+  return (
+    <div>
+      Help for Flow Data source queries
+    </div>
+  )
+}

--- a/src/datasources/flow-ds/help-README.md
+++ b/src/datasources/flow-ds/help-README.md
@@ -1,0 +1,1 @@
+# OpenNMS plugin for Grafana: Flow Data source

--- a/src/datasources/flow-ds/module.ts
+++ b/src/datasources/flow-ds/module.ts
@@ -1,21 +1,22 @@
-import { DataSourcePlugin } from '@grafana/data';
-import { FlowConfigEditor } from './FlowConfigEditor';
-import { FlowDataSource } from './FlowDataSource';
-import { FlowQueryEditor } from './FlowQueryEditor';
-import { FlowDataSourceOptions, FlowQuery } from './types';
-
+import { DataSourcePlugin } from '@grafana/data'
+import { FlowConfigEditor } from './FlowConfigEditor'
+import { FlowDataSource } from './FlowDataSource'
+import { FlowQueryEditor } from './FlowQueryEditor'
+import { FlowQueryEditorHelp } from './FlowQueryEditorHelp'
+import { FlowDataSourceOptions, FlowQuery } from './types'
 
 /**
  * Value that is used in the backend, but never sent over HTTP to the frontend
  */
 export interface BasicSecureJsonData {
-  apiKey?: string;
+  apiKey?: string
 }
 
 export type QueryTypesResponse = {
-  queryTypes: string[];
+  queryTypes: string[]
 };
 
 export const plugin = new DataSourcePlugin<FlowDataSource, FlowQuery, FlowDataSourceOptions>(FlowDataSource)
-.setConfigEditor(FlowConfigEditor)
-.setQueryEditor(FlowQueryEditor);
+  .setConfigEditor(FlowConfigEditor)
+  .setQueryEditor(FlowQueryEditor)
+  .setQueryEditorHelp(FlowQueryEditorHelp);

--- a/src/datasources/perf-ds/PerformanceQueryEditorHelp.tsx
+++ b/src/datasources/perf-ds/PerformanceQueryEditorHelp.tsx
@@ -1,0 +1,12 @@
+import React from 'react'
+import { QueryEditorHelpProps } from '@grafana/data'
+import { PerformanceQuery } from './types'
+
+export const PerformanceQueryEditorHelp: React.FC<QueryEditorHelpProps<PerformanceQuery>> = () => {
+
+  return (
+    <div>
+      Help for Performance Data source queries
+    </div>
+  )
+}

--- a/src/datasources/perf-ds/help-README.md
+++ b/src/datasources/perf-ds/help-README.md
@@ -1,0 +1,1 @@
+# OpenNMS plugin for Grafana: Performance Data source

--- a/src/datasources/perf-ds/module.ts
+++ b/src/datasources/perf-ds/module.ts
@@ -1,10 +1,12 @@
-import { DataSourcePlugin } from '@grafana/data';
-import { PerformanceConfigEditor } from './PerformanceConfigEditor';
-import { PerformanceDataSource } from './PerformanceDataSource';
-import { PerformanceQueryEditor } from './PerformanceQueryEditor';
-import { PerformanceDataSourceOptions, PerformanceQuery } from './types';
+import { DataSourcePlugin } from '@grafana/data'
+import { PerformanceConfigEditor } from './PerformanceConfigEditor'
+import { PerformanceDataSource } from './PerformanceDataSource'
+import { PerformanceQueryEditor } from './PerformanceQueryEditor'
+import { PerformanceQueryEditorHelp } from './PerformanceQueryEditorHelp'
+import { PerformanceDataSourceOptions, PerformanceQuery } from './types'
 
 
 export const plugin = new DataSourcePlugin<PerformanceDataSource, PerformanceQuery, PerformanceDataSourceOptions>(PerformanceDataSource)
-.setConfigEditor(PerformanceConfigEditor)
-.setQueryEditor(PerformanceQueryEditor);
+  .setConfigEditor(PerformanceConfigEditor)
+  .setQueryEditor(PerformanceQueryEditor)
+  .setQueryEditorHelp(PerformanceQueryEditorHelp);

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,5 +1,0 @@
-module.exports.getWebpackConfig = (config, options) => {
-  config.output.hashFunction = 'sha256';
-
-  return config;
-};

--- a/webpack.config.ts
+++ b/webpack.config.ts
@@ -1,0 +1,32 @@
+import type { Configuration } from 'webpack'
+import { merge } from 'webpack-merge'
+import CopyWebpackPlugin from 'copy-webpack-plugin'
+import grafanaConfig from './.config/webpack/webpack.config'
+import { getPluginJson } from './.config/webpack/utils'
+
+const config = async (env): Promise<Configuration> => {
+  const baseConfig = await grafanaConfig(env)
+  const pluginJson = getPluginJson()
+
+  return merge(baseConfig, {
+    // Add custom config here...
+    output: {
+      hashFunction: 'sha256',
+    },
+    plugins: [
+      // add README.md to datasources, this is what is displayed when clicking the "?" next to
+      // a datasource in the query editor.
+      // Grafana looks for 'README.md', but our 'README.md' is meant to be read by developers, not
+      // end users. This copies content meant for end user datasource help.
+      new CopyWebpackPlugin({
+        patterns: [
+          { from: 'datasources/entity-ds/help-README.md', to: 'datasources/entity-ds/README.md' },
+          { from: 'datasources/flow-ds/help-README.md', to: 'datasources/flow-ds/README.md' },
+          { from: 'datasources/perf-ds/help-README.md', to: 'datasources/perf-ds/README.md' },
+        ]
+      })
+    ]
+  })
+}
+
+export default config


### PR DESCRIPTION
Fix data source help. This PR basically wires things up so that help is displayed for data source help and query editor help. However, it doesn't include any actual contents for the help, this will need to be added.

## Data source help

This is the "?" button next to the data source dropdown in the Query Editor. Grafana looks for a `README.md` in the `datasources/ds-name` directory and displays it. However, our `README.md` were not being copied to the distribution. In addition, our files are more meant for developers to view them on GitHub, not for end users. Added `help-README.md` files which will contain any data source help text, these get copied in the webpack build process.

## Query Editor help

This is the "(i)" button inside an individual query and is part of the Grafana plugin query editor framework. It can change dynamically based on the contents of the query. This PR just handles wiring it up, it doesn't have any meaningful content.

## Webpack

Added a `webpack.config.ts` file at project root. This allows us to merge any customizations with the `.config/webpack/webpack.config.ts` that was generated by the Grafana migration tool.

# External References

* JIRA (Issue Tracker): https://opennms.atlassian.net/browse/HELM-302
* Continuous Integration: [CircleCI](https://circleci.com/gh/OpenNMS/opennms-helm)
