### PR TITLE
Fix issue when hiding mixed query types used in expression

### DIFF
--- a/src/datasources/perf-ds/queries/queryBuilder.ts
+++ b/src/datasources/perf-ds/queries/queryBuilder.ts
@@ -44,7 +44,6 @@ export const isValidMeasurementQuery = (query: OnmsMeasurementsQueryRequest) => 
 
 export const isValidAttributeTarget = (target: PerformanceQuery) => {
     if (!target ||
-        target.hide ||
         !(target.attribute &&
           (target.attribute.attribute.name || (target.attribute.attribute.label && OpenNMSGlob.hasGlob(target.attribute.attribute.label))) &&
           (target.attribute.resource.id || target.attribute.resource.label) &&
@@ -56,12 +55,12 @@ export const isValidAttributeTarget = (target: PerformanceQuery) => {
 }
 
 export const isValidExpressionTarget = (target: PerformanceQuery) => {
-    return (!target || target.hide || !(target.label && target.expression)) ? false : true
+    return (!target || !(target.label && target.expression)) ? false : true
 }
 
 // must specify basic filter info plus any required parameter values in filterState
 export const isValidFilterTarget = (target: PerformanceQuery) => {
-    if (!target || !target?.filter?.name || target.hide) {
+    if (!target || !target?.filter?.name) {
         return false
     }
 
@@ -108,7 +107,7 @@ export const buildAttributeQuerySource = (target: PerformanceQuery) => {
         attribute: attribute,
         ['fallback-attribute']: target.attribute.fallbackAttribute?.name || undefined,
         aggregation: target.attribute.aggregation?.label?.toUpperCase() || 'AVERAGE',
-        transient: false
+        transient: target.hide 
     } as OnmsMeasurementsQuerySource
 
     return source;
@@ -118,7 +117,7 @@ export const buildExpressionQuery = (target: PerformanceQuery, index: number) =>
     const expression = {
         label: target.label || 'expression' + index,
         value: target.expression,
-        transient: target.hide
+        transient: target.hide 
     } as OnmsMeasurementsQueryExpression
 
     return expression


### PR DESCRIPTION
Fixed issue when working with multiple query types, then hide some to allow better visibility.

As per old plugin Expression, Attribute and Filter queries should allow hidden queries in the payload since they define the transient attribute.

# Pull Request Check Sheet

* [ ] Have you read and followed our [Contribution Guidelines](https://github.com/OpenNMS/opennms/blob/develop/CONTRIBUTING.md)?
* [ ] Have you [made an issue in the OpenNMS issue tracker](https://issues.opennms.org)?<br>If so, you should:
  1. update the title of this PR to be of the format: `${JIRA-ISSUE-NUMBER}: subject of pull request`
  2. update the JIRA link at the bottom of this comment to refer to the real issue number
  3. prefix your commit messages with the issue number, if possible
* [ ] Have you made a comment in that issue which points back to this PR?
* [ ] Have you updated the JIRA link at the bottom of this comment to link to your issue?
* [ ] If this is a new feature, is there documentation?
* [ ] If this is a new feature or substantial change, are there tests that cover it?

# Pull Request Process

One or more reviewers should be assigned to each PR.

If you know that a particular person is subject matter expert in the area your PR affects, feel free to assign one or more reviewers when you create this PR, otherwise reviewers will be assigned for you.

Once the reviewer(s) accept the PR and the branch passes continuous integration in Bamboo, the PR is eligible for merge.

At that time, if you have commit access (are an OpenNMS Group employee or a member of the Order of the Green Polo) you are welcome to merge the PR.
Otherwise, a reviewer can merge it for you.

Thanks for taking time to contribute!

# External References

* JIRA (Issue Tracker): http://issues.opennms.org/browse/${JIRA-ISSUE-NUMBER}
* Continuous Integration: [CircleCI](https://circleci.com/gh/OpenNMS/opennms-helm)
