### PR TITLE
fix: some rest dto mapping, display results match between old and new…

### DIFF
--- a/src/datasources/perf-ds/PerformanceDataSource.tsx
+++ b/src/datasources/perf-ds/PerformanceDataSource.tsx
@@ -53,7 +53,7 @@ export class PerformanceDataSource extends DataSourceApi<PerformanceQuery> {
         const totalStrings = activeTargets.filter((t) =>
             t.performanceType.value &&
             t.performanceType.value === PerformanceTypeOptions.StringProperty.value &&
-            t.performanceState?.stringProperty?.value)
+            t.stringPropertyState?.stringProperty?.value)
         let typeOfQuery = 'normal'
 
         if (totalStrings.length > 0 && totalStrings.length === activeTargets.length) {

--- a/src/datasources/perf-ds/PerformanceQueryEditor.tsx
+++ b/src/datasources/perf-ds/PerformanceQueryEditor.tsx
@@ -44,11 +44,11 @@ export const PerformanceQueryEditor: React.FC<PerformanceQueryEditorProps> = ({ 
         onRunQuery();
     }
 
-   const updateStringQuery = (performanceState) => {
+   const updateStringQuery = (stringPropertyState) => {
         onChange({
             ...query,
             performanceType,
-            performanceState,
+            stringPropertyState,
         })
         onRunQuery();
     }
@@ -199,6 +199,7 @@ export const PerformanceQueryEditor: React.FC<PerformanceQueryEditorProps> = ({ 
                 isPerformanceType(PerformanceTypeOptions.StringProperty.value) &&
 
                 <PerformanceStringProperty
+                    query={query}
                     updateQuery={updateStringQuery}
                     loadNodes={loadNodes}
                     loadResourcesByNodeId={loadResourcesByNodeId}

--- a/src/datasources/perf-ds/PerformanceStringProperty.tsx
+++ b/src/datasources/perf-ds/PerformanceStringProperty.tsx
@@ -10,12 +10,13 @@ export const defaultPerformanceStringState = {
 }
 
 export const PerformanceStringProperty: React.FC<PerformanceStringPropertyProps> = ({
+    query,
     updateQuery,
     loadNodes,
     loadResourcesByNodeId,
 }) => {
 
-    const [performanceState, setPerformanceState] = useState<PerformanceStringPropertyState>(defaultPerformanceStringState)
+    const [performanceState, setPerformanceState] = useState<PerformanceStringPropertyState>(query.stringPropertyState || defaultPerformanceStringState)
 
     const setPerformanceStateProperty = (propertyName: string, propertyValue: unknown) => {
         setPerformanceState({ ...performanceState, [propertyName]: propertyValue })

--- a/src/datasources/perf-ds/types.ts
+++ b/src/datasources/perf-ds/types.ts
@@ -60,7 +60,7 @@ export interface PerformanceQuery extends DataQuery {
   attribute: PerformanceAttributeState;
   filter: PerformanceQueryFilter;
   filterState: { [key: string]: PerformanceQueryFilterStateItem};
-  performanceState: PerformanceStringPropertyState;
+  stringPropertyState: PerformanceStringPropertyState;
 }
 
 export interface PerformanceQueryRequest<T extends DataQuery> extends DataQueryRequest<T> {
@@ -186,6 +186,7 @@ export interface OnmsResourceDto {
 }
 
 export interface PerformanceStringPropertyProps {
+    query: PerformanceQuery;
     updateQuery: Function;
     loadNodes: (query?: string | undefined) => Promise<Array<SelectableValue<{ id: string }>>>;
     loadResourcesByNodeId: Function;


### PR DESCRIPTION
This PR does some fixes for Performance Datasource / String Property query type

- refactor a bit the rest dto mapping (reusing the common OnmsResourceDto)
- display results match between old and new version, 
- state for StringProperties

# Pull Request Check Sheet

* [ ] Have you read and followed our [Contribution Guidelines](https://github.com/OpenNMS/opennms/blob/develop/CONTRIBUTING.md)?
* [ ] Have you [made an issue in the OpenNMS issue tracker](https://issues.opennms.org)?<br>If so, you should:
  1. update the title of this PR to be of the format: `${JIRA-ISSUE-NUMBER}: subject of pull request`
  2. update the JIRA link at the bottom of this comment to refer to the real issue number
  3. prefix your commit messages with the issue number, if possible
* [ ] Have you made a comment in that issue which points back to this PR?
* [ ] Have you updated the JIRA link at the bottom of this comment to link to your issue?
* [ ] If this is a new feature, is there documentation?
* [ ] If this is a new feature or substantial change, are there tests that cover it?

# Pull Request Process

One or more reviewers should be assigned to each PR.

If you know that a particular person is subject matter expert in the area your PR affects, feel free to assign one or more reviewers when you create this PR, otherwise reviewers will be assigned for you.

Once the reviewer(s) accept the PR and the branch passes continuous integration in Bamboo, the PR is eligible for merge.

At that time, if you have commit access (are an OpenNMS Group employee or a member of the Order of the Green Polo) you are welcome to merge the PR.
Otherwise, a reviewer can merge it for you.

Thanks for taking time to contribute!

# External References

* JIRA (Issue Tracker): http://issues.opennms.org/browse/${JIRA-ISSUE-NUMBER}
* Continuous Integration: [CircleCI](https://circleci.com/gh/OpenNMS/opennms-helm)
