### PR TITLE
HELM-302: Fix circleci webpack command to point to main webpack.config.ts

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -84,7 +84,7 @@ commands:
           command: |
             export PATH="./node_modules/.bin:${PATH}"
             export NODE_OPTIONS=--openssl-legacy-provider
-            node --optimize-for-size --memory-reducer --max-old-space-size=12288 "$(command -v webpack)" -c ./.config/webpack/webpack.config.ts --env production
+            node --optimize-for-size --memory-reducer --max-old-space-size=12288 "$(command -v webpack)" -c ./webpack.config.ts --env production
             node --optimize-for-size --memory-reducer --max-old-space-size=12288 "$(command -v npx)" --yes @grafana/sign-plugin@latest
             unset NODE_OPTIONS
             


### PR DESCRIPTION
We updated our main `webpack.config.ts` to extend the grafana-generated `.config/webpack/webpack.config.ts`, but forgot to update the CircleCI `config.yml`. This is needed (among other things) to make sure the data source help files get included in the final output.


# External References

* JIRA (Issue Tracker): https://opennms.atlassian.net/browse/HELM-302
* Continuous Integration: [CircleCI](https://circleci.com/gh/OpenNMS/opennms-helm)
