### PR TITLE
Allow stringProperties query to use (single) template variables

### DIFF
--- a/src/datasources/perf-ds/PerformanceQueryEditor.tsx
+++ b/src/datasources/perf-ds/PerformanceQueryEditor.tsx
@@ -11,6 +11,7 @@ import { PerformanceStringProperty } from './PerformanceStringProperty';
 import { OnmsRrdGraphAttribute, PerformanceQueryEditorProps, QuickSelect } from './types';
 import { collectInterpolationVariables, interpolate } from './queries/interpolate'
 import { getRemoteResourceId } from './queries/queryBuilder'
+import { isTemplateVariable } from './PerformanceHelpers';
 
 export const PerformanceQueryEditor: React.FC<PerformanceQueryEditorProps> = ({ onChange, query, onRunQuery, datasource, ...rest }) => {
     const [performanceType, setPerformanceType] = useState<QuickSelect>(query.performanceType);
@@ -70,18 +71,20 @@ export const PerformanceQueryEditor: React.FC<PerformanceQueryEditorProps> = ({ 
      * Load resources for the PerformanceAttribute Resources dropdown by either a node id (selected from
      * Node dropdown) or from a template variable that evaluates to a node id.
      */
-    const loadResourcesByNode = async (value) => {
+    const loadResourcesByNode = async (value) => {    
         const ts = getTemplateSrv()
         let nodeId = value
-
-        if (ts.containsTemplate(value)) {
-            nodeId = ts.replace(value)
+        if(isTemplateVariable(value)){
+            nodeId = ts.replace(value.label)
+        }else if(value instanceof Object && value.id){
+            nodeId = value.id
         }
 
         return loadResourcesByNodeId(nodeId)
     }
 
     const loadResourcesByNodeId = async (nodeId) => {
+        
         const resourceData = await datasource.doResourcesForNodeRequest(nodeId)
 
         if (resourceData) {
@@ -202,7 +205,7 @@ export const PerformanceQueryEditor: React.FC<PerformanceQueryEditorProps> = ({ 
                     query={query}
                     updateQuery={updateStringQuery}
                     loadNodes={loadNodes}
-                    loadResourcesByNodeId={loadResourcesByNodeId}
+                    loadResourcesByNode={loadResourcesByNode}
                 />
             }
         </div>

--- a/src/datasources/perf-ds/PerformanceStringProperty.tsx
+++ b/src/datasources/perf-ds/PerformanceStringProperty.tsx
@@ -1,7 +1,8 @@
 import React, { useState, useEffect } from 'react'
-import { Segment, SegmentAsync } from '@grafana/ui';
+import { SegmentAsync } from '@grafana/ui';
 import { SegmentSectionWithIcon } from 'components/SegmentSectionWithIcon';
 import { PerformanceStringPropertyProps, PerformanceStringPropertyState } from './types';
+import { isTemplateVariable, getStringPropertiesForState } from './PerformanceHelpers'
 
 export const defaultPerformanceStringState = {
     node: { id: '' },
@@ -13,7 +14,7 @@ export const PerformanceStringProperty: React.FC<PerformanceStringPropertyProps>
     query,
     updateQuery,
     loadNodes,
-    loadResourcesByNodeId,
+    loadResourcesByNode,
 }) => {
 
     const [performanceState, setPerformanceState] = useState<PerformanceStringPropertyState>(query.stringPropertyState || defaultPerformanceStringState)
@@ -29,9 +30,6 @@ export const PerformanceStringProperty: React.FC<PerformanceStringPropertyProps>
     // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [performanceState])
 
-    const stringPropertyAttributes = Object.entries(performanceState?.resource?.stringPropertyAttributes).map(([key, item]) => {
-        return { label: key, value: key }
-    })
 
     return (
         <>
@@ -49,13 +47,13 @@ export const PerformanceStringProperty: React.FC<PerformanceStringPropertyProps>
             <div className='spacer' />
 
             {
-                performanceState?.node?.id &&
+                (performanceState?.node?.id  || isTemplateVariable(performanceState?.node)) &&
 
                 <SegmentSectionWithIcon label='Resource' icon='leaf'>
                     <SegmentAsync
                         value={performanceState?.resource}
                         placeholder='Select Resource'
-                        loadOptions={() => loadResourcesByNodeId(performanceState?.node?.id)}
+                        loadOptions={() => loadResourcesByNode(performanceState?.node)}
                         onChange={(value) => {
                             setPerformanceStateProperty('resource', value);
                         }}
@@ -64,13 +62,14 @@ export const PerformanceStringProperty: React.FC<PerformanceStringPropertyProps>
             }
             <div className='spacer' />
             {
-                performanceState?.node?.id && performanceState?.resource?.id &&
+                (performanceState?.node?.id || isTemplateVariable(performanceState?.node)) && 
+                (performanceState?.resource?.id || isTemplateVariable(performanceState?.resource)) &&
 
                 <SegmentSectionWithIcon label='String Property' icon='tag'>
-                    <Segment
+                    <SegmentAsync
                         value={performanceState?.stringProperty}
                         placeholder='Select String Property'
-                        options={stringPropertyAttributes}
+                        loadOptions={() => getStringPropertiesForState(performanceState, loadResourcesByNode)}
                         onChange={(value) => {
                             setPerformanceStateProperty('stringProperty', value);
                         }}

--- a/src/datasources/perf-ds/queries/queryStringProperties.ts
+++ b/src/datasources/perf-ds/queries/queryStringProperties.ts
@@ -48,7 +48,7 @@ const toStringFields = (node: OnmsResourceDto, resource: OnmsResourceDto, key: s
 const isDefinedStringPropertyQuery = (q: PerformanceQuery | undefined) => {
     const ps = q?.stringPropertyState
 
-    return ps && ps.node.id && ps.resource.id && ps.stringProperty.value ? true : false
+    return ps && (ps.node.id || ps.node.label) && (ps.resource.id || ps.resource.label) && ps.stringProperty.value ? true : false
 }
 
 export const getDefinedStringPropertyQueries = (templateSrv: TemplateSrv, targets: PerformanceQuery[]) => {
@@ -56,6 +56,8 @@ export const getDefinedStringPropertyQueries = (templateSrv: TemplateSrv, target
         .filter(q => !q.hide)
         .filter(isDefinedStringPropertyQuery)
         .map(q => {
+            const nodeId = q.stringPropertyState.node.id || q.stringPropertyState.node.label
+            const resourceId = q.stringPropertyState.resource.id || q.stringPropertyState.resource.label
             return {
                 //...q,
                 // DataQuery fields
@@ -66,8 +68,8 @@ export const getDefinedStringPropertyQueries = (templateSrv: TemplateSrv, target
                 datasource: q.datasource,
 
                 // StringPropertyQuery fields
-                nodeId: templateSrv.replace('' + q.stringPropertyState.node.id),
-                resourceId: templateSrv.replace(getResourceId(q.stringPropertyState.resource.id)),
+                nodeId: templateSrv.replace('' + nodeId),
+                resourceId: templateSrv.replace(getResourceId(resourceId)),
                 stringProperty: q.stringPropertyState.stringProperty.value
             } as DefinedStringPropertyQuery
         })

--- a/src/datasources/perf-ds/types.ts
+++ b/src/datasources/perf-ds/types.ts
@@ -189,11 +189,11 @@ export interface PerformanceStringPropertyProps {
     query: PerformanceQuery;
     updateQuery: Function;
     loadNodes: (query?: string | undefined) => Promise<Array<SelectableValue<{ id: string }>>>;
-    loadResourcesByNodeId: Function;
+    loadResourcesByNode: Function;
 }
 
 export interface PerformanceStringPropertyState {
-    node: { id: string };
-    resource: { id: string, stringPropertyAttributes: Record<string, string> };
+    node: { id?: string, label?: string };
+    resource: { id?: string, label?: string, stringPropertyAttributes?: Record<string, string> };
     stringProperty: { label: string, value: string };
 }


### PR DESCRIPTION

fix: to allow stringProperties query to use (single) template variables for node and resources

I'm creating a new PR to allow the use multiple template variables since this would affect all 4 queries (attributes, expressions, string properties and filter)

# Pull Request Check Sheet

* [ ] Have you read and followed our [Contribution Guidelines](https://github.com/OpenNMS/opennms/blob/develop/CONTRIBUTING.md)?
* [ ] Have you [made an issue in the OpenNMS issue tracker](https://issues.opennms.org)?<br>If so, you should:
  1. update the title of this PR to be of the format: `${JIRA-ISSUE-NUMBER}: subject of pull request`
  2. update the JIRA link at the bottom of this comment to refer to the real issue number
  3. prefix your commit messages with the issue number, if possible
* [ ] Have you made a comment in that issue which points back to this PR?
* [ ] Have you updated the JIRA link at the bottom of this comment to link to your issue?
* [ ] If this is a new feature, is there documentation?
* [ ] If this is a new feature or substantial change, are there tests that cover it?

# Pull Request Process

One or more reviewers should be assigned to each PR.

If you know that a particular person is subject matter expert in the area your PR affects, feel free to assign one or more reviewers when you create this PR, otherwise reviewers will be assigned for you.

Once the reviewer(s) accept the PR and the branch passes continuous integration in Bamboo, the PR is eligible for merge.

At that time, if you have commit access (are an OpenNMS Group employee or a member of the Order of the Green Polo) you are welcome to merge the PR.
Otherwise, a reviewer can merge it for you.

Thanks for taking time to contribute!

# External References

* JIRA (Issue Tracker): http://issues.opennms.org/browse/${JIRA-ISSUE-NUMBER}
* Continuous Integration: [CircleCI](https://circleci.com/gh/OpenNMS/opennms-helm)
