### PR TITLE
HELM-396: Click anywhere in Alarm Table for context menu

### DIFF
--- a/src/panels/alarm-table/AlarmTableMenu.tsx
+++ b/src/panels/alarm-table/AlarmTableMenu.tsx
@@ -5,49 +5,51 @@ import { Menu, MenuItem, useStyles2 } from '@grafana/ui'
 import { AlarmTableControlActions, AlarmTableControlState } from './AlarmTableTypes'
 
 interface AlarmTableMenuProps {
-    state: AlarmTableControlState,
-    actions: AlarmTableControlActions
+  state: AlarmTableControlState,
+  actions: AlarmTableControlActions
 }
 
 export const AlarmTableMenu: React.FC<AlarmTableMenuProps> = ({ state,actions }) => {
+  const selectedCount = state.indexes.filter(d => d === true).length
+  const suffix = selectedCount > 1 ? ` (${selectedCount})` : ''
 
-    let items = [
-      { label: 'Details', action: actions.details },
-      { type: 'divider', label: '', },
-      { label: 'Acknowledge', action: actions.acknowledge },
-      { label: 'Escalate', action: actions.escalate },
-      { label: 'Clear', action: actions.clear }
-    ]
+  let items = [
+    { label: 'Details', action: actions.details },
+    { type: 'divider', label: '', },
+    { label: `Acknowledge${suffix}`, action: actions.acknowledge },
+    { label: `Escalate${suffix}`, action: actions.escalate },
+    { label: `Clear${suffix}`, action: actions.clear }
+  ]
 
-    // If we have more than one item selected
-    // remove the ability to select Details
-    if (state.indexes.filter((d) => d === true).length > 1) {
-        items = items.splice(2, items.length)
+  // If we have more than one item selected
+  // remove the ability to select Details
+  if (selectedCount > 1) {
+    items = items.splice(2, items.length)
+  }
+
+  const getStyles = (theme: GrafanaTheme2) => {
+    return {
+      divider: css({
+        height: 1,
+        backgroundColor: theme.colors.border.weak,
+        margin: theme.spacing(0.5, 0)
+      })
     }
+  }
 
-    const getStyles = (theme: GrafanaTheme2) => {
-        return {
-            divider: css({
-                height: 1,
-                backgroundColor: theme.colors.border.weak,
-                margin: theme.spacing(0.5, 0)
-            })
+  const styles = useStyles2(getStyles)
+
+  return (
+    <Menu>
+      {items.map((item, index) => {
+        let elem = <MenuItem label={item.label} key={index} onClick={item.action} />
+
+        if (item.type === 'divider') {
+          elem = <div className={styles.divider}></div>
         }
-    }
 
-    const styles = useStyles2(getStyles)
-
-    return (
-        <Menu>
-            {items.map((item, index) => {
-                let elem = <MenuItem label={item.label} key={index} onClick={item.action} />
-              
-                if (item.type === 'divider') {
-                    elem = <div className={styles.divider}></div>
-                }
-
-                return elem;
-            })}
-        </Menu>
-    )
+        return elem
+      })}
+    </Menu>
+  )
 }

--- a/src/panels/alarm-table/hooks/useAlarm.ts
+++ b/src/panels/alarm-table/hooks/useAlarm.ts
@@ -12,7 +12,7 @@ export const useAlarm = (series: DataFrame[], soloIndex: number, client: ClientD
     useEffect(() => {
         if (series?.[0]?.name === 'alarms') {
             setAlarmQuery(true)
-            const localAlarmId = getAlarmIdFromFields(series?.[0].fields,soloIndex)
+            const localAlarmId = getAlarmIdFromFields(series?.[0].fields, soloIndex)
             setAlarmId(localAlarmId ?? -1)
         } else {
             setAlarmId(-1)
@@ -24,7 +24,7 @@ export const useAlarm = (series: DataFrame[], soloIndex: number, client: ClientD
     useEffect(() => {
         const updateAlarm = async () => {
             if (alarmId !== undefined && alarmId >= 0) {
-              const returnedAlarm = await client?.getAlarm(alarmId);
+              const returnedAlarm = await client?.getAlarm(alarmId)
               setAlarm(returnedAlarm)
             }
         }

--- a/src/panels/alarm-table/hooks/useAlarmTableMenu.ts
+++ b/src/panels/alarm-table/hooks/useAlarmTableMenu.ts
@@ -1,15 +1,16 @@
-import { useEffect, useRef, useState } from 'react'
+import { MutableRefObject, useEffect, useRef, useState } from 'react'
 
-export const useAlarmTableMenu = (rowClicked, series) => {
-
+export const useAlarmTableMenu = (indexes: MutableRefObject<boolean[]>, rowClicked, series, setState) => {
     const [menu, setMenu] = useState({ x: 0, y: 0 })
     const [menuOpen, setMenuOpen] = useState(false)
 
-    const table = useRef<HTMLDivElement>(null);
+    const table = useRef<HTMLDivElement>(null)
 
     const contextMenu = (index: number, e: MouseEvent) => {
         e.preventDefault()
-        rowClicked(index, e, true)
+        if (index >= 0) {
+            rowClicked(index, e, true)
+        }
         setMenu({ x: e.x, y: e.y })
         setMenuOpen(() => true)
     }
@@ -45,6 +46,10 @@ export const useAlarmTableMenu = (rowClicked, series) => {
 
       if (rowIndex >= 0) {
         rowClicked(rowIndex, e as MouseEvent, false)
+      } else {
+        // user clicked on table background, clear all selections
+        const newIndexes = indexes.current.map(x => false)
+        setState({ indexes: newIndexes, lastClicked: -1 })
       }
     }
 
@@ -53,6 +58,8 @@ export const useAlarmTableMenu = (rowClicked, series) => {
 
       if (rowIndex >= 0) {
         contextMenu(rowIndex, e as MouseEvent)
+      } else if (indexes.current.length > 0 && indexes.current.some(x => x === true)) {
+        contextMenu(-1, e as MouseEvent)
       }
     }
 

--- a/src/panels/alarm-table/hooks/useAlarmTableSelection.ts
+++ b/src/panels/alarm-table/hooks/useAlarmTableSelection.ts
@@ -35,11 +35,20 @@ export const useAlarmTableSelection = (doubleClicked) => {
                     { start: previousState.lastClicked, end: index }
 
                 for (let i = start; i <= end; i++) {
-                    newClickedIndexes[i] = true;
+                    newClickedIndexes[i] = true
                 }
 
                 setSoloIndex(-1)
+            } else if (fromContext && index >= 0) {
+                const countSelected = previousState.indexes.filter(x => x === true).length
+
+                if (countSelected < 2) {
+                  newClickedIndexes = clearIndexes(newClickedIndexes)
+                  newClickedIndexes[index] = true
+                  setSoloIndex(index)
+                }
             }
+
             return { indexes: newClickedIndexes, lastClicked: index }
         })
     }


### PR DESCRIPTION
Allow user to right-click (context click, could be Ctrl-click or double-tap on Mac) anywhere in the background area of the Alarm Table (not just on a row) to open the context menu.

Left-click results in deselecting any previously-selected rows.

Right-click (context click) will select new item and display context menu for that item, if there previously had been 0 or 1 items selected. If there were 2+ items selected, it will display context menu and not select item under it.

If there are multiple items selected, context menu displays number of items next to action, e.g. "Acknowledge (2)", etc.

# External References

* JIRA (Issue Tracker): https://opennms.atlassian.net/browse/HELM-396
* Continuous Integration: [CircleCI](https://circleci.com/gh/OpenNMS/grafana-plugin)
