### PR TITLE
Fix install-node-dependencies issue leading to swc errors

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -56,13 +56,22 @@ commands:
       - restore_cache:
           name: Restore NPM Cache
           keys:
-            - npm-packages-v3-{{ checksum "/tmp/filtered-package-lock.json" }}-{{ .Branch }}-{{ .Revision }}
-            - npm-packages-v3-{{ checksum "/tmp/filtered-package-lock.json" }}-{{ .Branch }}
-            - npm-packages-v3-{{ checksum "/tmp/filtered-package-lock.json" }}-
-            - npm-packages-v3-
+            - npm-packages-v4-{{ arch }}-{{ checksum "/tmp/filtered-package-lock.json" }}-{{ .Branch }}-{{ .Revision }}
+            - npm-packages-v4-{{ arch }}-{{ checksum "/tmp/filtered-package-lock.json" }}-{{ .Branch }}
+            - npm-packages-v4-{{ arch }}-{{ checksum "/tmp/filtered-package-lock.json" }}-
+            - npm-packages-v4-{{ arch }}-
       - run:
           name: Install Dependencies
-          command: npm --no-progress ci
+          command: |
+            npm --no-progress ci --include=optional
+            # Ensure platform-specific SWC binary is installed
+            SWC_ARCH="$(node -p "process.arch")"
+            SWC_PLATFORM="$(node -p "process.platform")"
+            if [ "$SWC_PLATFORM" = "linux" ]; then
+              SWC_PKG="@swc/core-linux-${SWC_ARCH}-gnu"
+              echo "Installing ${SWC_PKG}..."
+              npm install "${SWC_PKG}" --save-optional --ignore-scripts
+            fi
   save-node-cache:
     steps:
       - generate-node-cache-checksum
@@ -74,7 +83,7 @@ commands:
               fi
       - save_cache:
           name: Save Package Cache
-          key: npm-packages-v3-{{ checksum "/tmp/filtered-package-lock.json" }}-{{ .Branch }}-{{ .Revision }}
+          key: npm-packages-v4-{{ arch }}-{{ checksum "/tmp/filtered-package-lock.json" }}-{{ .Branch }}-{{ .Revision }}
           paths:
             - ~/.npm
   validate-schema:


### PR DESCRIPTION
Updates to `.circleci/config.yml` to fix `@swc/core` errors. This ensures that a platform-specific SWC binary is installed.

The project would build fine locally on a Mac but get the errors on CircleCI.

See https://opennms.atlassian.net/browse/OPG-513 for more detailed info.

# External References

* JIRA (Issue Tracker): http://issues.opennms.org/browse/OPG-513
* Continuous Integration: [CircleCI](https://circleci.com/gh/OpenNMS/grafana-plugin)
