### PR TITLE
OPG-515: Remove Cortex dashboard from list of pre-installed dashboards

### DIFF
--- a/src/plugin.json
+++ b/src/plugin.json
@@ -8,7 +8,7 @@
       "name": "The OpenNMS Group Inc.",
       "url": "https://www.opennms.com"
     },
-    "keywords": ["opennms", "opennms helm", "fault management", "performance management", "monitoring", "plugin", "snmp"],
+    "keywords": ["opennms", "grafana plugin", "fault management", "performance management", "monitoring", "plugin", "snmp"],
     "logos": {
       "small": "img/opennms-grafana-plugin.svg",
       "large": "img/opennms-grafana-plugin.svg"
@@ -25,7 +25,7 @@
       {"name": "Performance Data Source", "path": "img/Helm_Screenshot_Performance_Data_Source.png"}
     ],
     "version": "12.0.0-SNAPSHOT",
-    "updated": "2025-10-21"
+    "updated": "2026-03-11"
   },
   "includes": [
     {"type": "panel", "name": "Alarm Table","path":"panels/alarm-table/plugin.json"},
@@ -38,12 +38,11 @@
     {"type": "datasource", "name": "OpenNMS Flows","path":"datasources/flow-ds/plugin.json"},
     {"type": "dashboard", "name": "About | OpenNMS Plugin for Grafana", "path": "dashboards/about.json"},
     {"type": "dashboard", "name": "Flow Deep Dive | OpenNMS Plugin for Grafana", "path": "dashboards/flow_deep_dive.json"},
-    {"type": "dashboard", "name": "Cortex Flow Deep Dive | OpenNMS Plugin for Grafana", "path": "dashboards/cortex_flow_deep_dive.json"},
     {"type": "dashboard", "name": "Dashboard Converter | OpenNMS Plugin for Grafana", "path": "dashboards/dashboard_converter.json"}
   ],
   "dependencies": {
     "grafanaDependency": ">=12.0.0",
-    "grafanaVersion": "12.1.2",
+    "grafanaVersion": "12.4.0",
     "plugins": []
   },
   "$schema": "https://raw.githubusercontent.com/grafana/grafana/master/docs/sources/developers/plugins/plugin.schema.json"


### PR DESCRIPTION
Remove the Cortex Deep Dive dashboard from the list of pre-installed dashboards.

It's actually still included, but just won't show up on the list of dashboards to install.

# External References

* JIRA (Issue Tracker): http://issues.opennms.org/browse/OPG-515
* Continuous Integration: [CircleCI](https://circleci.com/gh/OpenNMS/grafana-plugin)
